### PR TITLE
Added new feature ‘pathDelays’

### DIFF
--- a/cmd/booted_message.go
+++ b/cmd/booted_message.go
@@ -1,5 +1,5 @@
 // Copyright 2023 Princess B33f Heavy Industries / Dave Shanley
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL
 
 package cmd
 

--- a/cmd/handle_http_traffic.go
+++ b/cmd/handle_http_traffic.go
@@ -1,5 +1,5 @@
 // Copyright 2023 Princess B33f Heavy Industries / Dave Shanley
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL
 
 package cmd
 

--- a/cmd/load_specification.go
+++ b/cmd/load_specification.go
@@ -1,5 +1,5 @@
 // Copyright 2023 Princess B33f Heavy Industries / Dave Shanley
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL
 
 package cmd
 

--- a/cmd/print_banner.go
+++ b/cmd/print_banner.go
@@ -1,5 +1,5 @@
 // Copyright 2023 Princess B33f Heavy Industries / Dave Shanley
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL
 
 package cmd
 

--- a/cmd/root_command.go
+++ b/cmd/root_command.go
@@ -1,5 +1,5 @@
 // Copyright 2023 Princess B33f Heavy Industries / Dave Shanley
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL
 
 package cmd
 
@@ -250,6 +250,12 @@ var (
 				printLoadedPathConfigurations(config.PathConfigurations)
 			}
 
+			// path delays
+			if len(config.PathDelays) > 0 {
+				config.CompilePathDelays()
+				printLoadedPathDelayConfigurations(config.PathDelays)
+			}
+
 			// static headers
 			if config.Headers != nil && len(config.Headers.DropHeaders) > 0 {
 				pterm.Info.Printf("Dropping the following %d %s globally:\n", len(config.Headers.DropHeaders),
@@ -352,6 +358,17 @@ func printLoadedPathConfigurations(configs map[string]*shared.WiretapPathConfig)
 		}
 		pterm.Println()
 	}
+}
+
+func printLoadedPathDelayConfigurations(pathDelays map[string]int) {
+	pterm.Info.Printf("Loaded %d path %s:\n", len(pathDelays),
+		shared.Pluralize(len(pathDelays), "delay", "delays"))
+
+	for k, v := range pathDelays {
+		pterm.Printf("⏱️ %sms --> %s\n", pterm.LightCyan(v), pterm.LightMagenta(k))
+	}
+	pterm.Println()
+
 }
 
 func printLoadedVariables(variables map[string]string) {

--- a/cmd/run_service.go
+++ b/cmd/run_service.go
@@ -1,5 +1,5 @@
 // Copyright 2023 Princess B33f Heavy Industries / Dave Shanley
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL
 
 package cmd
 

--- a/cmd/serve_monitor.go
+++ b/cmd/serve_monitor.go
@@ -1,5 +1,5 @@
 // Copyright 2023 Princess B33f Heavy Industries / Dave Shanley
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL
 
 package cmd
 

--- a/config/config_service.go
+++ b/config/config_service.go
@@ -1,5 +1,5 @@
 // Copyright 2023 Princess B33f Heavy Industries / Dave Shanley
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL
 
 package config
 

--- a/config/paths.go
+++ b/config/paths.go
@@ -1,5 +1,5 @@
 // Copyright 2023 Princess B33f Heavy Industries / Dave Shanley
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL
 
 package config
 
@@ -17,6 +17,16 @@ func FindPaths(path string, configuration *shared.WiretapConfiguration) []*share
 		}
 	}
 	return foundConfigurations
+}
+
+func FindPathDelay(path string, configuration *shared.WiretapConfiguration) int {
+	var foundMatch int
+	for key := range configuration.CompiledPathDelays {
+		if configuration.CompiledPathDelays[key].CompiledPathDelay.Match(path) {
+			foundMatch = configuration.CompiledPathDelays[key].PathDelayValue
+		}
+	}
+	return foundMatch
 }
 
 func RewritePath(path string, configuration *shared.WiretapConfiguration) string {

--- a/config/paths_test.go
+++ b/config/paths_test.go
@@ -1,5 +1,5 @@
 // Copyright 2023 Princess B33f Heavy Industries / Dave Shanley
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL
 
 package config
 
@@ -186,5 +186,31 @@ paths:
 
 	path := RewritePath("/en-US/burgerd/__raw/noKetchupPlease/nobody/yummy/yum?onions=true", &c)
 	assert.Equal(t, "http://localhost:80/noKetchupPlease/-/yummy/yum?onions=true", path)
+
+}
+
+func TestLocatePathDelay(t *testing.T) {
+
+	config := `pathDelays:
+  /pb33f/test/**: 1000
+  /pb33f/cakes/123: 2000
+  /*/test/123: 3000`
+
+	var c shared.WiretapConfiguration
+	_ = yaml.Unmarshal([]byte(config), &c)
+
+	c.CompilePathDelays()
+
+	delay := FindPathDelay("/pb33f/test/burgers/fries?1234=no", &c)
+	assert.Equal(t, 1000, delay)
+
+	delay = FindPathDelay("/pb33f/cakes/123", &c)
+	assert.Equal(t, 2000, delay)
+
+	delay = FindPathDelay("/roastbeef/test/123", &c)
+	assert.Equal(t, 3000, delay)
+
+	delay = FindPathDelay("/not-registered", &c)
+	assert.Equal(t, 0, delay)
 
 }

--- a/controls/controls_service.go
+++ b/controls/controls_service.go
@@ -1,5 +1,5 @@
 // Copyright 2023 Princess B33f Heavy Industries / Dave Shanley
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL
 
 package controls
 

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -1,5 +1,5 @@
 // Copyright 2023 Princess B33f Heavy Industries / Dave Shanley
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL
 
 package daemon
 

--- a/daemon/cors_middleware.go
+++ b/daemon/cors_middleware.go
@@ -1,5 +1,5 @@
 // Copyright 2023 Princess B33f Heavy Industries / Dave Shanley
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL
 
 package daemon
 

--- a/daemon/dto.go
+++ b/daemon/dto.go
@@ -1,5 +1,5 @@
 // Copyright 2023 Princess B33f Heavy Industries / Dave Shanley
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL
 
 package daemon
 

--- a/daemon/handle_request.go
+++ b/daemon/handle_request.go
@@ -1,5 +1,5 @@
 // Copyright 2023 Princess B33f Heavy Industries / Dave Shanley
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL
 
 package daemon
 
@@ -188,11 +188,16 @@ func (ws *WiretapService) handleHttpRequest(request *model.Request) {
 		}
 	}
 
-	// send response back to client.
-
-	if config.GlobalAPIDelay > 0 {
-		time.Sleep(time.Duration(config.GlobalAPIDelay) * time.Millisecond) // simulate a slow response.
+	// check if this path has a delay set.
+	delay := configModel.FindPathDelay(request.HttpRequest.URL.Path, config)
+	if delay > 0 {
+		time.Sleep(time.Duration(delay) * time.Millisecond) // simulate a slow response, configured for path.
+	} else {
+		if config.GlobalAPIDelay > 0 {
+			time.Sleep(time.Duration(config.GlobalAPIDelay) * time.Millisecond) // simulate a slow response.
+		}
 	}
+
 	body, _ := io.ReadAll(returnedResponse.Body)
 	headers := extractHeaders(returnedResponse)
 

--- a/daemon/monitor_static.go
+++ b/daemon/monitor_static.go
@@ -1,5 +1,5 @@
 // Copyright 2023 Princess B33f Heavy Industries / Dave Shanley
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL
 
 package daemon
 

--- a/daemon/validate.go
+++ b/daemon/validate.go
@@ -1,5 +1,5 @@
 // Copyright 2023 Princess B33f Heavy Industries / Dave Shanley
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL
 
 package daemon
 

--- a/daemon/wiretap_broadcast.go
+++ b/daemon/wiretap_broadcast.go
@@ -1,5 +1,5 @@
 // Copyright 2023 Princess B33f Heavy Industries / Dave Shanley
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL
 
 package daemon
 

--- a/daemon/wiretap_init.go
+++ b/daemon/wiretap_init.go
@@ -1,5 +1,5 @@
 // Copyright 2023 Princess B33f Heavy Industries / Dave Shanley
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL
 
 package daemon
 

--- a/daemon/wiretap_service.go
+++ b/daemon/wiretap_service.go
@@ -1,5 +1,5 @@
 // Copyright 2023 Princess Beef Heavy Industries LLC
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL
 
 package daemon
 

--- a/daemon/wiretap_utils.go
+++ b/daemon/wiretap_utils.go
@@ -1,5 +1,5 @@
 // Copyright 2023 Princess B33f Heavy Industries / Dave Shanley
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL
 
 package daemon
 

--- a/daemon/wiretap_utils_test.go
+++ b/daemon/wiretap_utils_test.go
@@ -1,5 +1,5 @@
 // Copyright 2023 Princess B33f Heavy Industries / Dave Shanley
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL
 
 package daemon
 

--- a/report/report_service.go
+++ b/report/report_service.go
@@ -1,5 +1,5 @@
 // Copyright 2023 Princess B33f Heavy Industries / Dave Shanley
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL
 
 package report
 

--- a/shared/error.go
+++ b/shared/error.go
@@ -1,5 +1,5 @@
 // Copyright 2023 Princess B33f Heavy Industries / Dave Shanley
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL
 
 package shared
 

--- a/shared/language.go
+++ b/shared/language.go
@@ -1,5 +1,5 @@
 // Copyright 2023 Princess B33f Heavy Industries / Dave Shanley
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL
 
 package shared
 

--- a/specs/spec_service.go
+++ b/specs/spec_service.go
@@ -1,5 +1,5 @@
 // Copyright 2023 Princess B33f Heavy Industries / Dave Shanley
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL
 
 package specs
 

--- a/wiretap.go
+++ b/wiretap.go
@@ -1,5 +1,5 @@
 // Copyright 2023 Princess B33f Heavy Industries / Dave Shanley
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: AGPL
 
 package main
 


### PR DESCRIPTION
Configure a delay for individual path globs! Global delay is the fallback now, indivdual delays are now configurable.

```yaml
pathDelays:
  "/very/slow/path": 7000
  "/not/so/slow/path": 2000
  "/faster/path": 300
```

Add individual delays in milliseconds for as many paths as required. All path keys are globs and can support wildcards (like `/some/*/path/**`