### PR TITLE
apply basePath to api request

### DIFF
--- a/daemon/api.go
+++ b/daemon/api.go
@@ -5,10 +5,11 @@ package daemon
 
 import (
 	"crypto/tls"
-	"github.com/pb33f/wiretap/config"
-	"github.com/pterm/pterm"
 	"net/http"
 	"net/url"
+
+	"github.com/pb33f/wiretap/config"
+	"github.com/pterm/pterm"
 
 	"github.com/pb33f/wiretap/shared"
 )
@@ -65,6 +66,7 @@ func (ws *WiretapService) callAPI(req *http.Request) (*http.Response, error) {
 		req.Header.Set("Referer", ReconstructURL(req,
 			wiretapConfig.RedirectProtocol,
 			wiretapConfig.RedirectHost,
+			wiretapConfig.RedirectBasePath,
 			wiretapConfig.RedirectPort))
 	}
 	resp, err := client.Do(req)

--- a/daemon/build_request.go
+++ b/daemon/build_request.go
@@ -6,15 +6,16 @@ package daemon
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/google/uuid"
-	"github.com/pb33f/wiretap/config"
-	"github.com/pb33f/wiretap/shared"
-	"github.com/pterm/pterm"
 	"io"
 	"net/http"
 	"net/url"
 	"strings"
 	"time"
+
+	"github.com/google/uuid"
+	"github.com/pb33f/wiretap/config"
+	"github.com/pb33f/wiretap/shared"
+	"github.com/pterm/pterm"
 )
 
 type HttpTransactionConfig struct {
@@ -153,10 +154,13 @@ func BuildHttpTransaction(build HttpTransactionConfig) *HttpTransaction {
 	}
 }
 
-func ReconstructURL(r *http.Request, protocol, host, port string) string {
+func ReconstructURL(r *http.Request, protocol, host, basepath string, port string) string {
 	url := fmt.Sprintf("%s://%s", protocol, host)
 	if port != "" {
 		url += fmt.Sprintf(":%s", port)
+	}
+	if basepath != "" {
+		url += basepath
 	}
 	if r.URL.Path != "" {
 		url += r.URL.Path

--- a/daemon/clone_request.go
+++ b/daemon/clone_request.go
@@ -7,16 +7,18 @@ import (
 	"bytes"
 	"encoding/base64"
 	"fmt"
-	"github.com/pb33f/wiretap/shared"
 	"io"
 	"net/http"
 	"strings"
+
+	"github.com/pb33f/wiretap/shared"
 )
 
 type CloneRequest struct {
 	Request       *http.Request
 	Protocol      string
 	Host          string
+	BasePath      string
 	Port          string
 	PathTarget    string
 	DropHeaders   []string
@@ -33,7 +35,7 @@ func CloneExistingRequest(request CloneRequest) *http.Request {
 
 	var newURL string
 	var newReq *http.Request
-	newURL = ReconstructURL(request.Request, request.Protocol, request.Host, request.Port)
+	newURL = ReconstructURL(request.Request, request.Protocol, request.Host, request.BasePath, request.Port)
 
 	// create cloned request
 	newReq, _ = http.NewRequest(request.Request.Method, newURL, io.NopCloser(bytes.NewBuffer(b)))

--- a/daemon/handle_request.go
+++ b/daemon/handle_request.go
@@ -6,17 +6,18 @@ package daemon
 import (
 	_ "embed"
 	"fmt"
-	"github.com/pb33f/libopenapi-validator/errors"
-	"github.com/pb33f/ranch/model"
-	"github.com/pb33f/ranch/plank/utils"
-	configModel "github.com/pb33f/wiretap/config"
-	"github.com/pb33f/wiretap/shared"
 	"io"
 	"net/http"
 	"os"
 	"path/filepath"
 	"text/template"
 	"time"
+
+	"github.com/pb33f/libopenapi-validator/errors"
+	"github.com/pb33f/ranch/model"
+	"github.com/pb33f/ranch/plank/utils"
+	configModel "github.com/pb33f/wiretap/config"
+	"github.com/pb33f/wiretap/shared"
 )
 
 //go:embed templates/socket-include.html
@@ -136,6 +137,7 @@ func (ws *WiretapService) handleHttpRequest(request *model.Request) {
 		Request:       request.HttpRequest,
 		Protocol:      config.RedirectProtocol,
 		Host:          config.RedirectHost,
+		BasePath:      config.RedirectBasePath,
 		Port:          config.RedirectPort,
 		DropHeaders:   dropHeaders,
 		InjectHeaders: injectHeaders,

--- a/daemon/wiretap_utils_test.go
+++ b/daemon/wiretap_utils_test.go
@@ -14,24 +14,30 @@ func TestReconstructURL(t *testing.T) {
 	protocol := "http"
 	host := "localhost"
 	port := "8000"
+	basePath := "/v1"
 	// Making sure trailing slashes are accounted for correctly
 	r, _ := http.NewRequest("GET", "http://localhost:1337/", nil)
-	assert.Equal(t, "http://localhost:8000/", ReconstructURL(r, protocol, host, port))
+	assert.Equal(t, "http://localhost:8000/", ReconstructURL(r, protocol, host, "", port))
 	r, _ = http.NewRequest("GET", "http://localhost:1337", nil)
-	assert.Equal(t, "http://localhost:8000", ReconstructURL(r, protocol, host, port))
+	assert.Equal(t, "http://localhost:8000", ReconstructURL(r, protocol, host, "", port))
 	// Adding port correctly
 	r, _ = http.NewRequest("GET", "http://localhost/", nil)
-	assert.Equal(t, "http://localhost/", ReconstructURL(r, protocol, host, ""))
+	assert.Equal(t, "http://localhost/", ReconstructURL(r, protocol, host, "", ""))
 	r, _ = http.NewRequest("GET", "http://localhost:8000", nil)
-	assert.Equal(t, "http://localhost", ReconstructURL(r, protocol, host, ""))
+	assert.Equal(t, "http://localhost", ReconstructURL(r, protocol, host, "", ""))
 	// Adding paths correctly
 	r, _ = http.NewRequest("POST", "http://localhost/dalek", nil)
-	assert.Equal(t, "http://localhost:8000/dalek", ReconstructURL(r, protocol, host, port))
+	assert.Equal(t, "http://localhost:8000/dalek", ReconstructURL(r, protocol, host, "", port))
 	r, _ = http.NewRequest("PUT", "http://localhost/dalek/1337", nil)
-	assert.Equal(t, "http://localhost/dalek/1337", ReconstructURL(r, protocol, host, ""))
+	assert.Equal(t, "http://localhost/dalek/1337", ReconstructURL(r, protocol, host, "", ""))
+	// Adding base path correctly
+	r, _ = http.NewRequest("GET", "http://localhost/dalek", nil)
+	assert.Equal(t, "http://localhost:8000/v1/dalek", ReconstructURL(r, protocol, host, basePath, port))
+	r, _ = http.NewRequest("GET", "http://localhost/dalek/1337", nil)
+	assert.Equal(t, "http://localhost/v1/dalek/1337", ReconstructURL(r, protocol, host, basePath, ""))
 	// Adding query params correctly
 	r, _ = http.NewRequest("GET", "http://localhost?doctor=who", nil)
-	assert.Equal(t, "http://localhost:8000?doctor=who", ReconstructURL(r, protocol, host, port))
+	assert.Equal(t, "http://localhost:8000?doctor=who", ReconstructURL(r, protocol, host, "", port))
 	r, _ = http.NewRequest("GET", "http://localhost:1337?doctor=who", nil)
-	assert.Equal(t, "http://localhost?doctor=who", ReconstructURL(r, protocol, host, ""))
+	assert.Equal(t, "http://localhost?doctor=who", ReconstructURL(r, protocol, host, "", ""))
 }


### PR DESCRIPTION
This PR adds the ability to have a base path to the api url for example `--url http://localhost:5001/api/v1`