### PR TITLE
fix: require the redirect URL flag

### DIFF
--- a/cmd/root_command.go
+++ b/cmd/root_command.go
@@ -108,6 +108,12 @@ var (
 			redirectURLFlag, _ := cmd.Flags().GetString("url")
 			if redirectURLFlag != "" {
 				redirectURL = redirectURLFlag
+			} else {
+				pterm.Println()
+				pterm.Error.Println("No redirect URL provided. " +
+					"Please provide a URL to redirect API traffic to using the --url or -u flags.")
+				pterm.Println()
+				return nil
 			}
 
 			globalAPIDelayFlag, _ := cmd.Flags().GetInt("delay")


### PR DESCRIPTION
**What**
Make the `--url / -u` flag required.
*    <img width="1168" alt="image" src="https://github.com/pb33f/wiretap/assets/1235638/10d6bc7c-751b-4ce4-aa02-7f214817cf23">


The error is now handled as well:
*    <img width="1502" alt="image" src="https://github.com/pb33f/wiretap/assets/1235638/9db16c28-5632-4566-bfc9-7db29c1b479a">

**Why**
Without enforcing/validating that this flag is set, wiretap users will experience a lot of exception issues. This is especially evident when it comes to request/context cloning where the full url is required to properly clone requests.


**Reproduction**
Before this PR, running wiretap without `--url` was allowed.
```shell
docker run -p 9090:9090 -p 9091:9091 -p 9092:9092 --rm -v $PWD:/work:rw  \
pb33f/wiretap --mock-mode --spec https://raw.githubusercontent.com/pb33f/libopenapi/main/test_specs/burgershop.openapi.yaml
```
