### PR TITLE
Fixed multi header handling by adapting model to actually be a slice

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@ wiretap
 # UI build
 ui/dist
 ui/node_modules
+
+# Jetbrains files
+.idea/
+

--- a/daemon/build_request.go
+++ b/daemon/build_request.go
@@ -182,10 +182,10 @@ func ReconstructURL(r *http.Request, protocol, host, basepath string, port strin
 	return url
 }
 
-func ExtractHeaders(resp *http.Response) map[string]any {
-	headers := make(map[string]any)
+func ExtractHeaders(resp *http.Response) map[string][]string {
+	headers := make(map[string][]string)
 	for k, v := range resp.Header {
-		headers[k] = v[0]
+		headers[k] = v
 	}
 	return headers
 }

--- a/daemon/handle_mock.go
+++ b/daemon/handle_mock.go
@@ -52,7 +52,7 @@ func (ws *WiretapService) handleMockRequest(
 	resp.Header = header
 	// write headers
 	for k, v := range headers {
-		for j := range v {
+		for _, j := range v {
 			request.HttpResponseWriter.Header().Set(k, fmt.Sprint(j))
 			header.Add(k, fmt.Sprint(v))
 		}

--- a/daemon/handle_mock.go
+++ b/daemon/handle_mock.go
@@ -37,9 +37,9 @@ func (ws *WiretapService) handleMockRequest(
 	time.Sleep(5 * time.Millisecond)
 
 	// wiretap needs to work from anywhere, so allow everything.
-	headers := make(map[string]any)
+	headers := make(map[string][]string)
 	setCORSHeaders(headers)
-	headers["Content-Type"] = "application/json"
+	headers["Content-Type"] = []string{"application/json"}
 
 	buff := bytes.NewBuffer(mock)
 
@@ -52,8 +52,10 @@ func (ws *WiretapService) handleMockRequest(
 	resp.Header = header
 	// write headers
 	for k, v := range headers {
-		request.HttpResponseWriter.Header().Set(k, fmt.Sprint(v))
-		header.Add(k, fmt.Sprint(v))
+		for j := range v {
+			request.HttpResponseWriter.Header().Set(k, fmt.Sprint(j))
+			header.Add(k, fmt.Sprint(v))
+		}
 	}
 
 	// if there was an error building the mock, return a 404

--- a/daemon/handle_request.go
+++ b/daemon/handle_request.go
@@ -215,7 +215,9 @@ func (ws *WiretapService) handleHttpRequest(request *model.Request) {
 
 	// write headers
 	for k, v := range headers {
-		request.HttpResponseWriter.Header().Set(k, fmt.Sprint(v))
+		for _, j := range v {
+			request.HttpResponseWriter.Header().Set(k, fmt.Sprint(j))
+		}
 	}
 	config.Logger.Info("[wiretap] request completed", "url", request.HttpRequest.URL.String(), "code", returnedResponse.StatusCode)
 
@@ -236,8 +238,8 @@ func (ws *WiretapService) handleHttpRequest(request *model.Request) {
 	_, _ = request.HttpResponseWriter.Write(body)
 }
 
-func setCORSHeaders(headers map[string]any) {
-	headers["Access-Control-Allow-Headers"] = "*"
-	headers["Access-Control-Allow-Origin"] = "*"
-	headers["Access-Control-Allow-Methods"] = "OPTIONS,POST,GET,DELETE,PATCH,PUT"
+func setCORSHeaders(headers map[string][]string) {
+	headers["Access-Control-Allow-Headers"] = []string{"*"}
+	headers["Access-Control-Allow-Origin"] = []string{"*"}
+	headers["Access-Control-Allow-Methods"] = []string{"OPTIONS,POST,GET,DELETE,PATCH,PUT"}
 }

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/lucasjones/reggen v0.0.0-20200904144131-37ba4fa293bb // indirect
 	github.com/pb33f/harhar v0.0.0-20240111233202-e393c2a39a60
 	github.com/pb33f/libopenapi v0.15.14
-	github.com/pb33f/libopenapi-validator v0.0.44
+	github.com/pb33f/libopenapi-validator v0.0.45
 	github.com/pb33f/ranch v0.4.0
 	github.com/pterm/pterm v0.12.76
 	golang.org/x/exp v0.0.0-20240213143201-ec583247a57a // indirect

--- a/go.mod
+++ b/go.mod
@@ -6,11 +6,11 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/lucasjones/reggen v0.0.0-20200904144131-37ba4fa293bb // indirect
 	github.com/pb33f/harhar v0.0.0-20240111233202-e393c2a39a60
-	github.com/pb33f/libopenapi v0.15.3
-	github.com/pb33f/libopenapi-validator v0.0.42
+	github.com/pb33f/libopenapi v0.15.14
+	github.com/pb33f/libopenapi-validator v0.0.44
 	github.com/pb33f/ranch v0.4.0
 	github.com/pterm/pterm v0.12.76
-	golang.org/x/exp v0.0.0-20240119083558-1b970713d09a // indirect
+	golang.org/x/exp v0.0.0-20240213143201-ec583247a57a // indirect
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -139,8 +139,10 @@ github.com/pb33f/harhar v0.0.0-20240111233202-e393c2a39a60 h1:5Nt5F1BxaYfbLolyD0
 github.com/pb33f/harhar v0.0.0-20240111233202-e393c2a39a60/go.mod h1:sJHiXr/Rdkg2j8P5FYGEcqPP1ptdk8zn6xeJ3aZfAvw=
 github.com/pb33f/libopenapi v0.15.3 h1:P3D4Vnuvct3PD9ctwGxmmvniBUrEs1A3GjQcSfxjQrg=
 github.com/pb33f/libopenapi v0.15.3/go.mod h1:m+4Pwri31UvcnZjuP8M7TlbR906DXJmMvYsbis234xg=
+github.com/pb33f/libopenapi v0.15.14/go.mod h1:PEXNwvtT4KNdjrwudp5OYnD1ryqK6uJ68aMNyWvoMuc=
 github.com/pb33f/libopenapi-validator v0.0.42 h1:bfwPWlxUFHtvPNi0PH+EVpQBU2kA3Db9rVdFkfmUVac=
 github.com/pb33f/libopenapi-validator v0.0.42/go.mod h1:kU1JYyXIRlpmsWx3NkL+drNNttLADMgdaNzJgXDhec0=
+github.com/pb33f/libopenapi-validator v0.0.44/go.mod h1:kU1JYyXIRlpmsWx3NkL+drNNttLADMgdaNzJgXDhec0=
 github.com/pb33f/ranch v0.4.0 h1:fve9Lozc9m0IGkygWD3EFkBtbRua+2gyi9yxYHvufh4=
 github.com/pb33f/ranch v0.4.0/go.mod h1:LfZITTWTb1quxakzKr2RErDdSGOrxV/dpai9DK4Aa6k=
 github.com/pelletier/go-toml/v2 v2.1.0 h1:FnwAJ4oYMvbT/34k9zzHuZNrhlz48GB3/s6at6/MHO4=
@@ -218,6 +220,7 @@ golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/exp v0.0.0-20240119083558-1b970713d09a h1:Q8/wZp0KX97QFTc2ywcOE0YRjZPVIx+MXInMzdvQqcA=
 golang.org/x/exp v0.0.0-20240119083558-1b970713d09a/go.mod h1:idGWGoKP1toJGkd5/ig9ZLuPcZBC3ewk7SzmH0uou08=
+golang.org/x/exp v0.0.0-20240213143201-ec583247a57a/go.mod h1:CxmFvTBINI24O/j8iY7H1xHzx2i4OsyguNBmN/uPtqc=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=
 golang.org/x/mod v0.8.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=

--- a/go.sum
+++ b/go.sum
@@ -139,10 +139,14 @@ github.com/pb33f/harhar v0.0.0-20240111233202-e393c2a39a60 h1:5Nt5F1BxaYfbLolyD0
 github.com/pb33f/harhar v0.0.0-20240111233202-e393c2a39a60/go.mod h1:sJHiXr/Rdkg2j8P5FYGEcqPP1ptdk8zn6xeJ3aZfAvw=
 github.com/pb33f/libopenapi v0.15.3 h1:P3D4Vnuvct3PD9ctwGxmmvniBUrEs1A3GjQcSfxjQrg=
 github.com/pb33f/libopenapi v0.15.3/go.mod h1:m+4Pwri31UvcnZjuP8M7TlbR906DXJmMvYsbis234xg=
+github.com/pb33f/libopenapi v0.15.14 h1:A0fn45jbthDyFGXfu5bYIZVsWyPI6hJYm3wG143MT8o=
 github.com/pb33f/libopenapi v0.15.14/go.mod h1:PEXNwvtT4KNdjrwudp5OYnD1ryqK6uJ68aMNyWvoMuc=
 github.com/pb33f/libopenapi-validator v0.0.42 h1:bfwPWlxUFHtvPNi0PH+EVpQBU2kA3Db9rVdFkfmUVac=
 github.com/pb33f/libopenapi-validator v0.0.42/go.mod h1:kU1JYyXIRlpmsWx3NkL+drNNttLADMgdaNzJgXDhec0=
+github.com/pb33f/libopenapi-validator v0.0.44 h1:z7SVS6mMVv/f4V73e9H1UCiWrMzMg2ubE6d/0FACfq8=
 github.com/pb33f/libopenapi-validator v0.0.44/go.mod h1:kU1JYyXIRlpmsWx3NkL+drNNttLADMgdaNzJgXDhec0=
+github.com/pb33f/libopenapi-validator v0.0.45 h1:UxTeaxwi2URM9RQlXNbke3zeibijz2kA28T3zVhmp/A=
+github.com/pb33f/libopenapi-validator v0.0.45/go.mod h1:kU1JYyXIRlpmsWx3NkL+drNNttLADMgdaNzJgXDhec0=
 github.com/pb33f/ranch v0.4.0 h1:fve9Lozc9m0IGkygWD3EFkBtbRua+2gyi9yxYHvufh4=
 github.com/pb33f/ranch v0.4.0/go.mod h1:LfZITTWTb1quxakzKr2RErDdSGOrxV/dpai9DK4Aa6k=
 github.com/pelletier/go-toml/v2 v2.1.0 h1:FnwAJ4oYMvbT/34k9zzHuZNrhlz48GB3/s6at6/MHO4=
@@ -220,6 +224,7 @@ golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/exp v0.0.0-20240119083558-1b970713d09a h1:Q8/wZp0KX97QFTc2ywcOE0YRjZPVIx+MXInMzdvQqcA=
 golang.org/x/exp v0.0.0-20240119083558-1b970713d09a/go.mod h1:idGWGoKP1toJGkd5/ig9ZLuPcZBC3ewk7SzmH0uou08=
+golang.org/x/exp v0.0.0-20240213143201-ec583247a57a h1:HinSgX1tJRX3KsL//Gxynpw5CTOAIPhgL4W8PNiIpVE=
 golang.org/x/exp v0.0.0-20240213143201-ec583247a57a/go.mod h1:CxmFvTBINI24O/j8iY7H1xHzx2i4OsyguNBmN/uPtqc=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=

--- a/mock/mock_engine_test.go
+++ b/mock/mock_engine_test.go
@@ -275,7 +275,7 @@ func TestNewMockEngine_BuildResponse_SimpleValid_Pretty(t *testing.T) {
 	doc := resetGiftshopState()
 	me := NewMockEngine(doc, true)
 
-	request, _ := http.NewRequest(http.MethodGet, "https://api.pb33f.io/wiretap/giftshop/products/pb0001", nil)
+	request, _ := http.NewRequest(http.MethodGet, "https://api.pb33f.io/wiretap/giftshop/products/bd1f3f70-d46f-4ea7-b178-de9a5abfe4d8", nil)
 	request.Header.Set(helpers.ContentTypeHeader, "application/json")
 
 	b, status, err := me.GenerateResponse(request)

--- a/mock/mock_engine_test.go
+++ b/mock/mock_engine_test.go
@@ -282,8 +282,8 @@ func TestNewMockEngine_BuildResponse_SimpleValid_Pretty(t *testing.T) {
 
 	assert.NoError(t, err)
 	assert.Equal(t, 200, status)
-	assert.Equal(t, "{\n  \"category\": \"shirts\",\n  \"description\": \"A t-shirt with the pb33f logo on the"+
-		" front\",\n  \"id\": \"d1404c5c-69bd-4cd2-a4cf-b47c79a30112\",\n  \"image\": \"https://pb33f.io/images/t-shirt.png\",\n "+
+	assert.Equal(t, "{\n  \"category\": \"shirts\",\n  \"description\": \"A t-shirt with the pb33f logo "+
+		"on it.\",\n  \"id\": \"d1404c5c-69bd-4cd2-a4cf-b47c79a30112\",\n  \"image\": \"https://pb33f.io/images/t-shirt.png\",\n "+
 		" \"name\": \"pb33f t-shirt\",\n  \"price\": 19.99,\n  \"shortCode\": \"pb0001\"\n}", string(b))
 }
 

--- a/ui/index.html
+++ b/ui/index.html
@@ -6,12 +6,12 @@
     <meta name="description"
           content="wiretap is a tool that sniffs your API traffic and validates it against an OpenAPI specification.">
     <script>
-        localStorage.setItem('wiretapPort', '%WIRETAP_PORT%')
-        localStorage.setItem('wiretapTLS', '%WIRETAP_TLS%')
-        localStorage.setItem('wiretapHost', '%WIRETAP_HOST%')
-        //localStorage.setItem('wiretapHost', 'localhost')
-        //localStorage.setItem('wiretapPort', '9092');
-        //localStorage.setItem('wiretapTLS', 'true');
+        // localStorage.setItem('wiretapPort', '%WIRETAP_PORT%')
+        // localStorage.setItem('wiretapTLS', '%WIRETAP_TLS%')
+        // localStorage.setItem('wiretapHost', '%WIRETAP_HOST%')
+        localStorage.setItem('wiretapHost', 'localhost')
+        localStorage.setItem('wiretapPort', '9092');
+        localStorage.setItem('wiretapTLS', 'true');
         const version = '%WIRETAP_VERSION%';
         const existingVersion = localStorage.getItem('wiretapVersion');
         if (existingVersion !== version) {


### PR DESCRIPTION
Headers need to be handled as a slice of strings, as headers can be duplicated in the HTTP spec. 