### PR TITLE
Provide more developer value via preferred header

### DIFF
--- a/mock/mock_engine.go
+++ b/mock/mock_engine.go
@@ -305,7 +305,8 @@ func (rme *ResponseMockEngine) runWorkflow(request *http.Request) ([]byte, int, 
     
     if preferred != "" {
         // If an explicit preferred header is present, let it have a chance to take precedence
-        // This can lead to a preferred header leading to a 3xx, 4xx, or 5xx example response.
+        // This allows a developer to cause a 3xx, 4xx, or 5xx mocked response by passing
+        // the appropriate example header value.
         mt, lo, noMT = rme.findMediaTypeContainingNamedExample(operation, request, preferred)
     }
     

--- a/mock/mock_engine_test.go
+++ b/mock/mock_engine_test.go
@@ -1009,3 +1009,106 @@ components:
 	assert.Equal(t, "sad cop", decoded["name"])
 	assert.Equal(t, "perhaps the saddest cyberpunk movie ever made.", decoded["description"])
 }
+
+func TestNewMockEngine_UseExamples_Preferred_First_200_Has_Hideous_Media_Type(t *testing.T) {
+// A little far-fetched for an API to behave this way,
+// where lowest 2xx response is html and second is json,
+// including the test case to catch a panic case
+	spec := `openapi: 3.1.0
+paths:
+  /test:
+    get:
+      responses:
+        '200':
+          content:
+            text/html:
+              schema:
+                $ref: '#/components/schemas/HtmlThing'
+              examples:
+                happyHtmlDays:
+                  value: <!DOCTYPE html><html lang="en"><body><h1>Happy Days</h1</body></html>
+                robocopInHtml:
+                  value: <!DOCTYPE html><html lang="en"><body><h1>Robo cop</h1</body></html>
+        '202':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Thing'
+              examples:
+                happyDays:
+                  value:
+                    name: happy days
+                    description: a terrible show from a time that never existed.
+                robocop:
+                  value:
+                    name: robocop
+                    description: perhaps the best cyberpunk movie ever made.
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorThing'
+              examples:
+                sadErrorDays:
+                  value:
+                    name: sad error days
+                    description: a sad error prone show
+                sadcop:
+                  value:
+                    name: sad cop
+                    description: perhaps the saddest cyberpunk movie ever made.
+components:
+  schemas:
+    Thing:
+      type: object
+      properties:
+        name:
+          type: string
+          example: nameExample
+        description:
+          type: string
+          example: descriptionExample
+    HtmlThing:
+      type: string
+    ErrorThing:
+      type: object
+      properties:
+        name:
+          type: string
+          example: errorNameExample
+        description:
+          type: string
+          example: errorDescriptionExample
+`
+
+	d, _ := libopenapi.NewDocument([]byte(spec))
+	doc, _ := d.BuildV3Model()
+
+	me := NewMockEngine(&doc.Model, false)
+
+	// Check that we don't panic if first 2xx does not match media type
+	request, _ := http.NewRequest(http.MethodGet, "https://api.pb33f.io/test", nil)
+	request.Header.Set(helpers.Preferred, "robocop")
+
+	b, status, err := me.GenerateResponse(request)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 202, status)
+
+	var decoded map[string]any
+	_ = json.Unmarshal(b, &decoded)
+
+	assert.Equal(t, "robocop", decoded["name"])
+	assert.Equal(t, "perhaps the best cyberpunk movie ever made.", decoded["description"])
+
+	// Now see if html will work
+	request, _ = http.NewRequest(http.MethodGet, "https://api.pb33f.io/test", nil)
+	request.Header.Set(helpers.Preferred, "happyHtmlDays")
+	request.Header.Set("Content-Type", "text/html")
+
+	b, status, err = me.GenerateResponse(request)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 200, status)
+	assert.Equal(t, "<!DOCTYPE html><html lang=\"en\"><body><h1>Happy Days</h1</body></html>", string(b[:]))
+}

--- a/mock/mock_engine_test.go
+++ b/mock/mock_engine_test.go
@@ -6,14 +6,13 @@ package mock
 import (
 	"bytes"
 	"encoding/json"
-	"io"
-	"net/http"
-	"testing"
-
 	"github.com/pb33f/libopenapi"
 	"github.com/pb33f/libopenapi-validator/helpers"
 	v3 "github.com/pb33f/libopenapi/datamodel/high/v3"
 	"github.com/stretchr/testify/assert"
+	"io"
+	"net/http"
+	"testing"
 )
 
 // var doc *v3.Document
@@ -845,85 +844,6 @@ components:
 }
 
 // https://github.com/pb33f/wiretap/issues/84
-func TestNewMockEngine_UseExamples_Preferred_From_400(t *testing.T) {
-
-	spec := `openapi: 3.1.0
-paths:
-  /test:
-    get:
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Thing'
-              examples:
-                happyDays:
-                  value:
-                    name: happy days
-                    description: a terrible show from a time that never existed.
-                robocop:
-                  value:
-                    name: robocop
-                    description: perhaps the best cyberpunk movie ever made.
-        '400':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorThing'
-              examples:
-                sadErrorDays:
-                  value:
-                    name: sad error days
-                    description: a sad error prone show
-                sadcop:
-                  value:
-                    name: sad cop
-                    description: perhaps the saddest cyberpunk movie ever made.
-components:
-  schemas:
-    Thing:
-      type: object
-      properties:
-        name:
-          type: string
-          example: nameExample
-        description:
-          type: string
-          example: descriptionExample
-    ErrorThing:
-      type: object
-      properties:
-        name:
-          type: string
-          example: errorNameExample
-        description:
-          type: string
-          example: errorDescriptionExample
-`
-
-	d, _ := libopenapi.NewDocument([]byte(spec))
-	doc, _ := d.BuildV3Model()
-
-	me := NewMockEngine(&doc.Model, false)
-
-	request, _ := http.NewRequest(http.MethodGet, "https://api.pb33f.io/test", nil)
-	request.Header.Set(helpers.Preferred, "sadcop")
-
-	b, status, err := me.GenerateResponse(request)
-
-	assert.NoError(t, err)
-	assert.Equal(t, 400, status)
-
-	var decoded map[string]any
-	_ = json.Unmarshal(b, &decoded)
-
-	assert.Equal(t, "sad cop", decoded["name"])
-	assert.Equal(t, "perhaps the saddest cyberpunk movie ever made.", decoded["description"])
-
-}
-
-// https://github.com/pb33f/wiretap/issues/84
 func TestNewMockEngine_UseExamples_FromSchema(t *testing.T) {
 
 	spec := `openapi: 3.1.0
@@ -1011,4 +931,81 @@ components:
 	assert.NotEmpty(t, decoded["name"])
 	assert.NotEmpty(t, decoded["description"])
 
+}
+
+func TestNewMockEngine_UseExamples_Preferred_From_400(t *testing.T) {
+
+	spec := `openapi: 3.1.0
+paths:
+  /test:
+    get:
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Thing'
+              examples:
+                happyDays:
+                  value:
+                    name: happy days
+                    description: a terrible show from a time that never existed.
+                robocop:
+                  value:
+                    name: robocop
+                    description: perhaps the best cyberpunk movie ever made.
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorThing'
+              examples:
+                sadErrorDays:
+                  value:
+                    name: sad error days
+                    description: a sad error prone show
+                sadcop:
+                  value:
+                    name: sad cop
+                    description: perhaps the saddest cyberpunk movie ever made.
+components:
+  schemas:
+    Thing:
+      type: object
+      properties:
+        name:
+          type: string
+          example: nameExample
+        description:
+          type: string
+          example: descriptionExample
+    ErrorThing:
+      type: object
+      properties:
+        name:
+          type: string
+          example: errorNameExample
+        description:
+          type: string
+          example: errorDescriptionExample
+`
+
+	d, _ := libopenapi.NewDocument([]byte(spec))
+	doc, _ := d.BuildV3Model()
+
+	me := NewMockEngine(&doc.Model, false)
+
+	request, _ := http.NewRequest(http.MethodGet, "https://api.pb33f.io/test", nil)
+	request.Header.Set(helpers.Preferred, "sadcop")
+
+	b, status, err := me.GenerateResponse(request)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 400, status)
+
+	var decoded map[string]any
+	_ = json.Unmarshal(b, &decoded)
+
+	assert.Equal(t, "sad cop", decoded["name"])
+	assert.Equal(t, "perhaps the saddest cyberpunk movie ever made.", decoded["description"])
 }

--- a/mock/mock_engine_test.go
+++ b/mock/mock_engine_test.go
@@ -1010,10 +1010,10 @@ components:
 	assert.Equal(t, "perhaps the saddest cyberpunk movie ever made.", decoded["description"])
 }
 
-func TestNewMockEngine_UseExamples_Preferred_First_200_Has_Hideous_Media_Type(t *testing.T) {
+func TestNewMockEngine_UseExamples_Preferred_200_Not_Json(t *testing.T) {
 // A little far-fetched for an API to behave this way,
 // where lowest 2xx response is html and second is json,
-// including the test case to catch a panic case
+// including the test case just in case
 	spec := `openapi: 3.1.0
 paths:
   /test:


### PR DESCRIPTION
I've been delighted by `wiretap.` 

As I've used it, I've often wished it could easily mock negative cases that are traditionally hard to test in services which are meant to not fail.

With a small change here to the mock server's algorithm for deciding selection of a mock response, we can unlock even more value from wiretap by mocking negative cases.