### PR TITLE
Added support for Websockets

### DIFF
--- a/cmd/handle_http_traffic.go
+++ b/cmd/handle_http_traffic.go
@@ -27,11 +27,26 @@ func handleHttpTraffic(wiretapConfig *shared.WiretapConfiguration, wtService *da
 			wtService.HandleHttpRequest(requestModel)
 		}
 
+		handleWebsocket := func(w http.ResponseWriter, r *http.Request) {
+			id, _ := uuid.NewUUID()
+			requestModel := &model.Request{
+				Id:                 &id,
+				HttpRequest:        r,
+				HttpResponseWriter: w,
+			}
+			wtService.HandleWebsocketRequest(requestModel)
+		}
+
 		// create a new mux.
 		mux := http.NewServeMux()
 
 		// handle the index
 		mux.HandleFunc("/", handleTraffic)
+
+		// Handle Websockets
+		for websocket := range wiretapConfig.WebsocketConfigs {
+			mux.HandleFunc(websocket, handleWebsocket)
+		}
 
 		pterm.Info.Println(pterm.LightMagenta(fmt.Sprintf("API Gateway UI booting on port %s...", wiretapConfig.Port)))
 

--- a/cmd/root_command.go
+++ b/cmd/root_command.go
@@ -349,6 +349,16 @@ var (
 				printLoadedRedirectAllowList(config.RedirectAllowList)
 			}
 
+			if len(config.WebsocketConfigs) > 0 {
+				for _, config := range config.WebsocketConfigs {
+					if config.VerifyCert == nil {
+						config.VerifyCert = func() *bool { b := true; return &b }()
+					}
+				}
+
+				printLoadedWebsockets(config.WebsocketConfigs)
+			}
+
 			// static headers
 			if config.Headers != nil && len(config.Headers.DropHeaders) > 0 {
 				pterm.Info.Printf("Dropping the following %d %s globally:\n", len(config.Headers.DropHeaders),
@@ -625,8 +635,7 @@ func Execute(version, commit, date string, fs embed.FS) {
 	rootCmd.Flags().IntP("hard-validation-code", "q", 400, "Set a custom http error code for non-compliant requests when using the hard-error flag")
 	rootCmd.Flags().IntP("hard-validation-return-code", "y", 502, "Set a custom http error code for non-compliant responses when using the hard-error flag")
 	rootCmd.Flags().BoolP("mock-mode", "x", false, "Run in mock mode, responses are mocked and no traffic is sent to the target API (requires OpenAPI spec)")
-	rootCmd.Flags().StringP("config", "c", "",
-		"Location of wiretap configuration file to use (default is .wiretap in current directory)")
+	rootCmd.Flags().StringP("config", "c", "", "Location of wiretap configuration file to use (default is .wiretap in current directory)")
 	rootCmd.Flags().StringP("base", "b", "", "Set a base path to resolve relative file references from, or a overriding base URL to resolve remote references from")
 	rootCmd.Flags().BoolP("debug", "l", false, "Enable debug logging")
 	rootCmd.Flags().StringP("har", "z", "", "Load a HAR file instead of sniffing traffic")
@@ -706,11 +715,20 @@ func printLoadedIgnoreRedirectPaths(ignoreRedirects []string) {
 }
 
 func printLoadedRedirectAllowList(allowRedirects []string) {
-	pterm.Info.Printf("Loaded %d allows listed redirect %s :\n", len(allowRedirects),
+	pterm.Info.Printf("Loaded %d allows listed redirect %s:\n", len(allowRedirects),
 		shared.Pluralize(len(allowRedirects), "path", "paths"))
 
 	for _, x := range allowRedirects {
 		pterm.Printf("🐵 Paths matching '%s' will always follow redirects, regardless of ignoreRedirect settings\n", pterm.LightCyan(x))
+	}
+	pterm.Println()
+}
+
+func printLoadedWebsockets(websockets map[string]*shared.WiretapWebsocketConfig) {
+	pterm.Info.Printf("Loaded %d %s: \n", len(websockets), shared.Pluralize(len(websockets), "websocket", "websockets"))
+
+	for websocket := range websockets {
+		pterm.Printf("🔌 Paths prefixed '%s' will be managed as a websocket\n", pterm.LightCyan(websocket))
 	}
 	pterm.Println()
 }

--- a/daemon/handle_request.go
+++ b/daemon/handle_request.go
@@ -298,7 +298,7 @@ func (ws *WiretapService) handleWebsocketRequest(request *model.Request) {
 	dialer.TLSClientConfig = &tls.Config{InsecureSkipVerify: !*websocketConfig.VerifyCert}
 	serverConn, _, err := dialer.Dial(newRequest.URL.String(), newRequest.Header)
 	if err != nil {
-		ws.config.Logger.Error("Unable to create server connection")
+		ws.config.Logger.Error(fmt.Sprintf("Unable to connect to remote server; websocket connection failed: %s", err))
 		return
 	}
 	defer func(serverConn *websocket.Conn) {
@@ -386,7 +386,7 @@ func getCloseCode(err error) (int, bool) {
 
 func logWebsocketClose(config *shared.WiretapConfiguration, closeCode int, isUnexpected bool) {
 	if isUnexpected {
-		config.Logger.Error(fmt.Sprintf("Websocket closed unexepectedly with code: %d", closeCode))
+		config.Logger.Warn(fmt.Sprintf("Websocket closed unexepectedly with code: %d", closeCode))
 	} else {
 		config.Logger.Info(fmt.Sprintf("Websocket closed expectedly with code: %d", closeCode))
 	}

--- a/daemon/wiretap_service.go
+++ b/daemon/wiretap_service.go
@@ -95,6 +95,9 @@ func (ws *WiretapService) HandleServiceRequest(request *model.Request, core serv
 }
 
 func (ws *WiretapService) HandleHttpRequest(request *model.Request) {
-
 	ws.handleHttpRequest(request)
+}
+
+func (ws *WiretapService) HandleWebsocketRequest(request *model.Request) {
+	ws.handleWebsocketRequest(request)
 }

--- a/shared/config.go
+++ b/shared/config.go
@@ -13,49 +13,50 @@ import (
 )
 
 type WiretapConfiguration struct {
-	Contract                  string                        `json:"-" yaml:"-"`
-	RedirectHost              string                        `json:"redirectHost,omitempty" yaml:"redirectHost,omitempty"`
-	RedirectPort              string                        `json:"redirectPort,omitempty" yaml:"redirectPort,omitempty"`
-	RedirectBasePath          string                        `json:"redirectBasePath,omitempty" yaml:"redirectBasePath,omitempty"`
-	RedirectProtocol          string                        `json:"redirectProtocol,omitempty" yaml:"redirectProtocol,omitempty"`
-	RedirectURL               string                        `json:"redirectURL,omitempty" yaml:"redirectURL,omitempty"`
-	Port                      string                        `json:"port,omitempty" yaml:"port,omitempty"`
-	MonitorPort               string                        `json:"monitorPort,omitempty" yaml:"monitorPort,omitempty"`
-	WebSocketHost             string                        `json:"webSocketHost,omitempty" yaml:"webSocketHost,omitempty"`
-	WebSocketPort             string                        `json:"webSocketPort,omitempty" yaml:"webSocketPort,omitempty"`
-	GlobalAPIDelay            int                           `json:"globalAPIDelay,omitempty" yaml:"globalAPIDelay,omitempty"`
-	StaticDir                 string                        `json:"staticDir,omitempty" yaml:"staticDir,omitempty"`
-	StaticIndex               string                        `json:"staticIndex,omitempty" yaml:"staticIndex,omitempty"`
-	PathConfigurations        map[string]*WiretapPathConfig `json:"paths,omitempty" yaml:"paths,omitempty"`
-	Headers                   *WiretapHeaderConfig          `json:"headers,omitempty" yaml:"headers,omitempty"`
-	StaticPaths               []string                      `json:"staticPaths,omitempty" yaml:"staticPaths,omitempty"`
-	Variables                 map[string]string             `json:"variables,omitempty" yaml:"variables,omitempty"`
-	Spec                      string                        `json:"contract,omitempty" yaml:"contract,omitempty"`
-	Certificate               string                        `json:"certificate,omitempty" yaml:"certificate,omitempty"`
-	CertificateKey            string                        `json:"certificateKey,omitempty" yaml:"certificateKey,omitempty"`
-	HardErrors                bool                          `json:"hardValidation,omitempty" yaml:"hardValidation,omitempty"`
-	HardErrorCode             int                           `json:"hardValidationCode,omitempty" yaml:"hardValidationCode,omitempty"`
-	HardErrorReturnCode       int                           `json:"hardValidationReturnCode,omitempty" yaml:"hardValidationReturnCode,omitempty"`
-	PathDelays                map[string]int                `json:"pathDelays,omitempty" yaml:"pathDelays,omitempty"`
-	MockMode                  bool                          `json:"mockMode,omitempty" yaml:"mockMode,omitempty"`
-	MockModePretty            bool                          `json:"mockModePretty,omitempty" yaml:"mockModePretty,omitempty"`
-	Base                      string                        `json:"base,omitempty" yaml:"base,omitempty"`
-	HAR                       string                        `json:"har,omitempty" yaml:"har,omitempty"`
-	HARValidate               bool                          `json:"harValidate,omitempty" yaml:"harValidate,omitempty"`
-	HARPathAllowList          []string                      `json:"harPathAllowList,omitempty" yaml:"harPathAllowList,omitempty"`
-	StreamReport              bool                          `json:"streamReport,omitempty" yaml:"streamReport,omitempty"`
-	ReportFile                string                        `json:"reportFilename,omitempty" yaml:"reportFilename,omitempty"`
-	IgnoreRedirects           []string                      `json:"ignoreRedirects,omitempty" yaml:"ignoreRedirects,omitempty"`
-	RedirectAllowList         []string                      `json:"redirectAllowList,omitempty" yaml:"redirectAllowList,omitempty"`
-	HARFile                   *harhar.HAR                   `json:"-" yaml:"-"`
-	CompiledPathDelays        map[string]*CompiledPathDelay `json:"-" yaml:"-"`
-	CompiledVariables         map[string]*CompiledVariable  `json:"-" yaml:"-"`
-	Version                   string                        `json:"-" yaml:"-"`
-	StaticPathsCompiled       []glob.Glob                   `json:"-" yaml:"-"`
-	CompiledPaths             map[string]*CompiledPath      `json:"-"`
-	CompiledIgnoreRedirects   []*CompiledRedirect           `json:"-" yaml:"-"`
-	CompiledRedirectAllowList []*CompiledRedirect           `json:"-" yaml:"-"`
-	FS                        embed.FS                      `json:"-"`
+	Contract                  string                             `json:"-" yaml:"-"`
+	RedirectHost              string                             `json:"redirectHost,omitempty" yaml:"redirectHost,omitempty"`
+	RedirectPort              string                             `json:"redirectPort,omitempty" yaml:"redirectPort,omitempty"`
+	RedirectBasePath          string                             `json:"redirectBasePath,omitempty" yaml:"redirectBasePath,omitempty"`
+	RedirectProtocol          string                             `json:"redirectProtocol,omitempty" yaml:"redirectProtocol,omitempty"`
+	RedirectURL               string                             `json:"redirectURL,omitempty" yaml:"redirectURL,omitempty"`
+	Port                      string                             `json:"port,omitempty" yaml:"port,omitempty"`
+	MonitorPort               string                             `json:"monitorPort,omitempty" yaml:"monitorPort,omitempty"`
+	WebSocketHost             string                             `json:"webSocketHost,omitempty" yaml:"webSocketHost,omitempty"`
+	WebSocketPort             string                             `json:"webSocketPort,omitempty" yaml:"webSocketPort,omitempty"`
+	GlobalAPIDelay            int                                `json:"globalAPIDelay,omitempty" yaml:"globalAPIDelay,omitempty"`
+	StaticDir                 string                             `json:"staticDir,omitempty" yaml:"staticDir,omitempty"`
+	StaticIndex               string                             `json:"staticIndex,omitempty" yaml:"staticIndex,omitempty"`
+	PathConfigurations        map[string]*WiretapPathConfig      `json:"paths,omitempty" yaml:"paths,omitempty"`
+	Headers                   *WiretapHeaderConfig               `json:"headers,omitempty" yaml:"headers,omitempty"`
+	StaticPaths               []string                           `json:"staticPaths,omitempty" yaml:"staticPaths,omitempty"`
+	Variables                 map[string]string                  `json:"variables,omitempty" yaml:"variables,omitempty"`
+	Spec                      string                             `json:"contract,omitempty" yaml:"contract,omitempty"`
+	Certificate               string                             `json:"certificate,omitempty" yaml:"certificate,omitempty"`
+	CertificateKey            string                             `json:"certificateKey,omitempty" yaml:"certificateKey,omitempty"`
+	HardErrors                bool                               `json:"hardValidation,omitempty" yaml:"hardValidation,omitempty"`
+	HardErrorCode             int                                `json:"hardValidationCode,omitempty" yaml:"hardValidationCode,omitempty"`
+	HardErrorReturnCode       int                                `json:"hardValidationReturnCode,omitempty" yaml:"hardValidationReturnCode,omitempty"`
+	PathDelays                map[string]int                     `json:"pathDelays,omitempty" yaml:"pathDelays,omitempty"`
+	MockMode                  bool                               `json:"mockMode,omitempty" yaml:"mockMode,omitempty"`
+	MockModePretty            bool                               `json:"mockModePretty,omitempty" yaml:"mockModePretty,omitempty"`
+	Base                      string                             `json:"base,omitempty" yaml:"base,omitempty"`
+	HAR                       string                             `json:"har,omitempty" yaml:"har,omitempty"`
+	HARValidate               bool                               `json:"harValidate,omitempty" yaml:"harValidate,omitempty"`
+	HARPathAllowList          []string                           `json:"harPathAllowList,omitempty" yaml:"harPathAllowList,omitempty"`
+	StreamReport              bool                               `json:"streamReport,omitempty" yaml:"streamReport,omitempty"`
+	ReportFile                string                             `json:"reportFilename,omitempty" yaml:"reportFilename,omitempty"`
+	IgnoreRedirects           []string                           `json:"ignoreRedirects,omitempty" yaml:"ignoreRedirects,omitempty"`
+	RedirectAllowList         []string                           `json:"redirectAllowList,omitempty" yaml:"redirectAllowList,omitempty"`
+	WebsocketConfigs          map[string]*WiretapWebsocketConfig `json:"websockets" yaml:"websockets"`
+	HARFile                   *harhar.HAR                        `json:"-" yaml:"-"`
+	CompiledPathDelays        map[string]*CompiledPathDelay      `json:"-" yaml:"-"`
+	CompiledVariables         map[string]*CompiledVariable       `json:"-" yaml:"-"`
+	Version                   string                             `json:"-" yaml:"-"`
+	StaticPathsCompiled       []glob.Glob                        `json:"-" yaml:"-"`
+	CompiledPaths             map[string]*CompiledPath           `json:"-"`
+	CompiledIgnoreRedirects   []*CompiledRedirect                `json:"-" yaml:"-"`
+	CompiledRedirectAllowList []*CompiledRedirect                `json:"-" yaml:"-"`
+	FS                        embed.FS                           `json:"-"`
 	Logger                    *slog.Logger
 }
 
@@ -123,6 +124,11 @@ func (wtc *WiretapConfiguration) ReplaceWithVariables(input string) string {
 		}
 	}
 	return input
+}
+
+type WiretapWebsocketConfig struct {
+	VerifyCert  *bool    `json:"verifyCert" yaml:"verifyCert"`
+	DropHeaders []string `json:"dropHeaders" yaml:"dropHeaders"`
 }
 
 type WiretapPathConfig struct {


### PR DESCRIPTION
This MR aims to add support for proxying websockets to wiretap.

It skips validation on this endpoint as OpenAPI does not really support websocket specification.

I am not the most familiar with gorilla/websocket so I may have missed something.