### PR TITLE
Add Request Validation Filtering

### DIFF
--- a/cmd/root_command.go
+++ b/cmd/root_command.go
@@ -366,7 +366,12 @@ var (
 
 			if len(config.IgnoreValidation) > 0 {
 				config.CompileIgnoreValidations()
-				// TODO: add print command
+				printLoadedIgnoreValidationPaths(config.IgnoreValidation)
+			}
+
+			if len(config.ValidationAllowList) > 0 {
+				config.CompileValidationAllowList()
+				printLoadedValidationAllowList(config.ValidationAllowList)
 			}
 
 			// static headers
@@ -725,7 +730,7 @@ func printLoadedIgnoreRedirectPaths(ignoreRedirects []string) {
 }
 
 func printLoadedRedirectAllowList(allowRedirects []string) {
-	pterm.Info.Printf("Loaded %d allows listed redirect %s:\n", len(allowRedirects),
+	pterm.Info.Printf("Loaded %d allow listed redirect %s:\n", len(allowRedirects),
 		shared.Pluralize(len(allowRedirects), "path", "paths"))
 
 	for _, x := range allowRedirects {
@@ -739,6 +744,26 @@ func printLoadedWebsockets(websockets map[string]*shared.WiretapWebsocketConfig)
 
 	for websocket := range websockets {
 		pterm.Printf("🔌 Paths prefixed '%s' will be managed as a websocket\n", pterm.LightCyan(websocket))
+	}
+	pterm.Println()
+}
+
+func printLoadedIgnoreValidationPaths(ignoreValidations []string) {
+	pterm.Info.Printf("Loaded %d %s to ignore validation:\n", len(ignoreValidations),
+		shared.Pluralize(len(ignoreValidations), "path", "paths"))
+
+	for _, x := range ignoreValidations {
+		pterm.Printf("⚖️ Paths matching '%s' will not have requests validated\n", pterm.LightCyan(x))
+	}
+	pterm.Println()
+}
+
+func printLoadedValidationAllowList(validationAllowList []string) {
+	pterm.Info.Printf("Loaded %d allow listed validation paths %s :\n", len(validationAllowList),
+		shared.Pluralize(len(validationAllowList), "path", "paths"))
+
+	for _, x := range validationAllowList {
+		pterm.Printf("👮 Paths matching '%s' will always have validation run, regardless of ignoreValidation settings\n", pterm.LightCyan(x))
 	}
 	pterm.Println()
 }

--- a/cmd/root_command.go
+++ b/cmd/root_command.go
@@ -359,6 +359,16 @@ var (
 				printLoadedWebsockets(config.WebsocketConfigs)
 			}
 
+			if len(config.ValidationAllowList) > 0 {
+				config.CompileIgnoreValidations()
+				// TODO: add print command
+			}
+
+			if len(config.IgnoreValidation) > 0 {
+				config.CompileIgnoreValidations()
+				// TODO: add print command
+			}
+
 			// static headers
 			if config.Headers != nil && len(config.Headers.DropHeaders) > 0 {
 				pterm.Info.Printf("Dropping the following %d %s globally:\n", len(config.Headers.DropHeaders),

--- a/config/paths.go
+++ b/config/paths.go
@@ -48,8 +48,8 @@ func PathRedirectAllowListed(path string, configuration *shared.WiretapConfigura
 }
 
 func IgnoreValidationOnPath(path string, configuration *shared.WiretapConfiguration) bool {
-	for _, redirectPath := range configuration.CompiledIgnoreValidations {
-		if redirectPath.CompiledPath.Match(path) {
+	for _, validationPath := range configuration.CompiledIgnoreValidations {
+		if validationPath.CompiledPath.Match(path) {
 			return true
 		}
 	}
@@ -57,8 +57,8 @@ func IgnoreValidationOnPath(path string, configuration *shared.WiretapConfigurat
 }
 
 func PathValidationAllowListed(path string, configuration *shared.WiretapConfiguration) bool {
-	for _, redirectPath := range configuration.CompiledIgnoreValidations {
-		if redirectPath.CompiledPath.Match(path) {
+	for _, validationPath := range configuration.CompiledValidationAllowList {
+		if validationPath.CompiledPath.Match(path) {
 			return true
 		}
 	}

--- a/config/paths.go
+++ b/config/paths.go
@@ -47,6 +47,24 @@ func PathRedirectAllowListed(path string, configuration *shared.WiretapConfigura
 	return false
 }
 
+func IgnoreValidationOnPath(path string, configuration *shared.WiretapConfiguration) bool {
+	for _, redirectPath := range configuration.CompiledIgnoreValidations {
+		if redirectPath.CompiledPath.Match(path) {
+			return true
+		}
+	}
+	return false
+}
+
+func PathValidationAllowListed(path string, configuration *shared.WiretapConfiguration) bool {
+	for _, redirectPath := range configuration.CompiledIgnoreValidations {
+		if redirectPath.CompiledPath.Match(path) {
+			return true
+		}
+	}
+	return false
+}
+
 func RewritePath(path string, configuration *shared.WiretapConfiguration) string {
 	paths := FindPaths(path, configuration)
 	var replaced string = path

--- a/config/paths_test.go
+++ b/config/paths_test.go
@@ -308,3 +308,5 @@ func TestRedirectAllowList_NoPathsRegistered(t *testing.T) {
 	assert.False(t, ignore)
 
 }
+
+// TODO: add tests for new validation functions

--- a/config/paths_test.go
+++ b/config/paths_test.go
@@ -309,4 +309,96 @@ func TestRedirectAllowList_NoPathsRegistered(t *testing.T) {
 
 }
 
-// TODO: add tests for new validation functions
+func TestIgnoreValidation(t *testing.T) {
+
+	config := `ignoreValidation:
+  - /pb33f/test/**
+  - /pb33f/cakes/123
+  - /*/test/123`
+
+	var c shared.WiretapConfiguration
+	_ = yaml.Unmarshal([]byte(config), &c)
+
+	c.CompileIgnoreValidations()
+
+	ignore := IgnoreValidationOnPath("/pb33f/test/burgers/fries?1234=no", &c)
+	assert.True(t, ignore)
+
+	ignore = IgnoreValidationOnPath("/pb33f/cakes/123", &c)
+	assert.True(t, ignore)
+
+	ignore = IgnoreValidationOnPath("/roastbeef/test/123", &c)
+	assert.True(t, ignore)
+
+	ignore = IgnoreValidationOnPath("/not-registered", &c)
+	assert.False(t, ignore)
+
+}
+
+func TestIgnoreValidation_NoPathsRegistered(t *testing.T) {
+
+	var c shared.WiretapConfiguration
+	_ = yaml.Unmarshal([]byte(""), &c)
+
+	c.CompileIgnoreValidations()
+
+	ignore := IgnoreValidationOnPath("/pb33f/test/burgers/fries?1234=no", &c)
+	assert.False(t, ignore)
+
+	ignore = IgnoreValidationOnPath("/pb33f/cakes/123", &c)
+	assert.False(t, ignore)
+
+	ignore = IgnoreValidationOnPath("/roastbeef/test/123", &c)
+	assert.False(t, ignore)
+
+	ignore = IgnoreValidationOnPath("/not-registered", &c)
+	assert.False(t, ignore)
+
+}
+
+func TestValidationAllowList(t *testing.T) {
+
+	config := `validationAllowList:
+  - /pb33f/test/**
+  - /pb33f/cakes/123
+  - /*/test/123`
+
+	var c shared.WiretapConfiguration
+	_ = yaml.Unmarshal([]byte(config), &c)
+
+	c.CompileValidationAllowList()
+
+	ignore := PathValidationAllowListed("/pb33f/test/burgers/fries?1234=no", &c)
+	assert.True(t, ignore)
+
+	ignore = PathValidationAllowListed("/pb33f/cakes/123", &c)
+	assert.True(t, ignore)
+
+	ignore = PathValidationAllowListed("/roastbeef/test/123", &c)
+	assert.True(t, ignore)
+
+	ignore = PathValidationAllowListed("/not-registered", &c)
+	assert.False(t, ignore)
+
+}
+
+func TestValidationAllowList_NoPathsRegistered(t *testing.T) {
+
+	var c shared.WiretapConfiguration
+	_ = yaml.Unmarshal([]byte(""), &c)
+
+	c.CompileValidationAllowList()
+
+	ignore := PathValidationAllowListed("/pb33f/test/burgers/fries?1234=no", &c)
+	assert.False(t, ignore)
+
+	ignore = PathValidationAllowListed("/pb33f/cakes/123", &c)
+	assert.False(t, ignore)
+
+	ignore = PathValidationAllowListed("/roastbeef/test/123", &c)
+	assert.False(t, ignore)
+
+	ignore = PathValidationAllowListed("/not-registered", &c)
+	assert.False(t, ignore)
+
+}

--- a/daemon/handle_request.go
+++ b/daemon/handle_request.go
@@ -131,17 +131,21 @@ func (ws *WiretapService) handleHttpRequest(request *model.Request) {
 
 	ws.config.Logger.Info("[wiretap] handling API request", "url", request.HttpRequest.URL.String())
 
-	// check if we're going to fail hard on validation errors. (default is to skip this)
-	if ws.config.HardErrors && !ws.config.MockMode {
+	if ws.config.MockMode {
+		// TODO: Add logging
+
+	} else if configModel.IgnoreValidationOnPath(apiRequest.URL.Path, ws.config) && !configModel.PathValidationAllowListed(apiRequest.URL.Path, ws.config) {
+		// TODO: Add logging
+
+		// check if we're going to fail hard on validation errors. (default is to skip this)
+	} else if ws.config.HardErrors {
 
 		// validate the request synchronously
 		requestErrors = ws.ValidateRequest(request, newReq)
 
 	} else {
 		// validate the request asynchronously
-		if !ws.config.MockMode {
-			go ws.ValidateRequest(request, newReq)
-		}
+		go ws.ValidateRequest(request, newReq)
 	}
 
 	// short-circuit if we're using mock mode, there is no API call to make.

--- a/daemon/validate.go
+++ b/daemon/validate.go
@@ -53,16 +53,8 @@ func (ws *WiretapService) ValidateRequest(
 		_, validationErrors = validator.ValidateHttpRequest(httpRequest)
 	}
 
-	pm := false
-	for i := range validationErrors {
-		if validationErrors[i].IsPathMissingError() {
-			if !pm {
-				cleanedErrors = append(cleanedErrors, validationErrors[i])
-				pm = true
-			}
-		} else {
-			cleanedErrors = append(cleanedErrors, validationErrors[i])
-		}
+	for _, validationError := range validationErrors {
+		cleanedErrors = append(cleanedErrors, validationError)
 	}
 	// record results
 	buildTransConfig := HttpTransactionConfig{

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/lucasjones/reggen v0.0.0-20200904144131-37ba4fa293bb // indirect
 	github.com/pb33f/harhar v0.0.0-20240111233202-e393c2a39a60
 	github.com/pb33f/libopenapi v0.15.14
-	github.com/pb33f/libopenapi-validator v0.0.45
+	github.com/pb33f/libopenapi-validator v0.0.48
 	github.com/pb33f/ranch v0.4.0
 	github.com/pterm/pterm v0.12.76
 	golang.org/x/exp v0.0.0-20240213143201-ec583247a57a // indirect

--- a/shared/config.go
+++ b/shared/config.go
@@ -13,51 +13,55 @@ import (
 )
 
 type WiretapConfiguration struct {
-	Contract                  string                             `json:"-" yaml:"-"`
-	RedirectHost              string                             `json:"redirectHost,omitempty" yaml:"redirectHost,omitempty"`
-	RedirectPort              string                             `json:"redirectPort,omitempty" yaml:"redirectPort,omitempty"`
-	RedirectBasePath          string                             `json:"redirectBasePath,omitempty" yaml:"redirectBasePath,omitempty"`
-	RedirectProtocol          string                             `json:"redirectProtocol,omitempty" yaml:"redirectProtocol,omitempty"`
-	RedirectURL               string                             `json:"redirectURL,omitempty" yaml:"redirectURL,omitempty"`
-	Port                      string                             `json:"port,omitempty" yaml:"port,omitempty"`
-	MonitorPort               string                             `json:"monitorPort,omitempty" yaml:"monitorPort,omitempty"`
-	WebSocketHost             string                             `json:"webSocketHost,omitempty" yaml:"webSocketHost,omitempty"`
-	WebSocketPort             string                             `json:"webSocketPort,omitempty" yaml:"webSocketPort,omitempty"`
-	GlobalAPIDelay            int                                `json:"globalAPIDelay,omitempty" yaml:"globalAPIDelay,omitempty"`
-	StaticDir                 string                             `json:"staticDir,omitempty" yaml:"staticDir,omitempty"`
-	StaticIndex               string                             `json:"staticIndex,omitempty" yaml:"staticIndex,omitempty"`
-	PathConfigurations        map[string]*WiretapPathConfig      `json:"paths,omitempty" yaml:"paths,omitempty"`
-	Headers                   *WiretapHeaderConfig               `json:"headers,omitempty" yaml:"headers,omitempty"`
-	StaticPaths               []string                           `json:"staticPaths,omitempty" yaml:"staticPaths,omitempty"`
-	Variables                 map[string]string                  `json:"variables,omitempty" yaml:"variables,omitempty"`
-	Spec                      string                             `json:"contract,omitempty" yaml:"contract,omitempty"`
-	Certificate               string                             `json:"certificate,omitempty" yaml:"certificate,omitempty"`
-	CertificateKey            string                             `json:"certificateKey,omitempty" yaml:"certificateKey,omitempty"`
-	HardErrors                bool                               `json:"hardValidation,omitempty" yaml:"hardValidation,omitempty"`
-	HardErrorCode             int                                `json:"hardValidationCode,omitempty" yaml:"hardValidationCode,omitempty"`
-	HardErrorReturnCode       int                                `json:"hardValidationReturnCode,omitempty" yaml:"hardValidationReturnCode,omitempty"`
-	PathDelays                map[string]int                     `json:"pathDelays,omitempty" yaml:"pathDelays,omitempty"`
-	MockMode                  bool                               `json:"mockMode,omitempty" yaml:"mockMode,omitempty"`
-	MockModePretty            bool                               `json:"mockModePretty,omitempty" yaml:"mockModePretty,omitempty"`
-	Base                      string                             `json:"base,omitempty" yaml:"base,omitempty"`
-	HAR                       string                             `json:"har,omitempty" yaml:"har,omitempty"`
-	HARValidate               bool                               `json:"harValidate,omitempty" yaml:"harValidate,omitempty"`
-	HARPathAllowList          []string                           `json:"harPathAllowList,omitempty" yaml:"harPathAllowList,omitempty"`
-	StreamReport              bool                               `json:"streamReport,omitempty" yaml:"streamReport,omitempty"`
-	ReportFile                string                             `json:"reportFilename,omitempty" yaml:"reportFilename,omitempty"`
-	IgnoreRedirects           []string                           `json:"ignoreRedirects,omitempty" yaml:"ignoreRedirects,omitempty"`
-	RedirectAllowList         []string                           `json:"redirectAllowList,omitempty" yaml:"redirectAllowList,omitempty"`
+	Contract                    string                        `json:"-" yaml:"-"`
+	RedirectHost                string                        `json:"redirectHost,omitempty" yaml:"redirectHost,omitempty"`
+	RedirectPort                string                        `json:"redirectPort,omitempty" yaml:"redirectPort,omitempty"`
+	RedirectBasePath            string                        `json:"redirectBasePath,omitempty" yaml:"redirectBasePath,omitempty"`
+	RedirectProtocol            string                        `json:"redirectProtocol,omitempty" yaml:"redirectProtocol,omitempty"`
+	RedirectURL                 string                        `json:"redirectURL,omitempty" yaml:"redirectURL,omitempty"`
+	Port                        string                        `json:"port,omitempty" yaml:"port,omitempty"`
+	MonitorPort                 string                        `json:"monitorPort,omitempty" yaml:"monitorPort,omitempty"`
+	WebSocketHost               string                        `json:"webSocketHost,omitempty" yaml:"webSocketHost,omitempty"`
+	WebSocketPort               string                        `json:"webSocketPort,omitempty" yaml:"webSocketPort,omitempty"`
+	GlobalAPIDelay              int                           `json:"globalAPIDelay,omitempty" yaml:"globalAPIDelay,omitempty"`
+	StaticDir                   string                        `json:"staticDir,omitempty" yaml:"staticDir,omitempty"`
+	StaticIndex                 string                        `json:"staticIndex,omitempty" yaml:"staticIndex,omitempty"`
+	PathConfigurations          map[string]*WiretapPathConfig `json:"paths,omitempty" yaml:"paths,omitempty"`
+	Headers                     *WiretapHeaderConfig          `json:"headers,omitempty" yaml:"headers,omitempty"`
+	StaticPaths                 []string                      `json:"staticPaths,omitempty" yaml:"staticPaths,omitempty"`
+	Variables                   map[string]string             `json:"variables,omitempty" yaml:"variables,omitempty"`
+	Spec                        string                        `json:"contract,omitempty" yaml:"contract,omitempty"`
+	Certificate                 string                        `json:"certificate,omitempty" yaml:"certificate,omitempty"`
+	CertificateKey              string                        `json:"certificateKey,omitempty" yaml:"certificateKey,omitempty"`
+	HardErrors                  bool                          `json:"hardValidation,omitempty" yaml:"hardValidation,omitempty"`
+	HardErrorCode               int                           `json:"hardValidationCode,omitempty" yaml:"hardValidationCode,omitempty"`
+	HardErrorReturnCode         int                           `json:"hardValidationReturnCode,omitempty" yaml:"hardValidationReturnCode,omitempty"`
+	PathDelays                  map[string]int                `json:"pathDelays,omitempty" yaml:"pathDelays,omitempty"`
+	MockMode                    bool                          `json:"mockMode,omitempty" yaml:"mockMode,omitempty"`
+	MockModePretty              bool                          `json:"mockModePretty,omitempty" yaml:"mockModePretty,omitempty"`
+	Base                        string                        `json:"base,omitempty" yaml:"base,omitempty"`
+	HAR                         string                        `json:"har,omitempty" yaml:"har,omitempty"`
+	HARValidate                 bool                          `json:"harValidate,omitempty" yaml:"harValidate,omitempty"`
+	HARPathAllowList            []string                      `json:"harPathAllowList,omitempty" yaml:"harPathAllowList,omitempty"`
+	StreamReport                bool                          `json:"streamReport,omitempty" yaml:"streamReport,omitempty"`
+	ReportFile                  string                        `json:"reportFilename,omitempty" yaml:"reportFilename,omitempty"`
+	IgnoreRedirects             []string                      `json:"ignoreRedirects,omitempty" yaml:"ignoreRedirects,omitempty"`
+	RedirectAllowList           []string                      `json:"redirectAllowList,omitempty" yaml:"redirectAllowList,omitempty"`
 	WebsocketConfigs          map[string]*WiretapWebsocketConfig `json:"websockets" yaml:"websockets"`
-	HARFile                   *harhar.HAR                        `json:"-" yaml:"-"`
-	CompiledPathDelays        map[string]*CompiledPathDelay      `json:"-" yaml:"-"`
-	CompiledVariables         map[string]*CompiledVariable       `json:"-" yaml:"-"`
-	Version                   string                             `json:"-" yaml:"-"`
-	StaticPathsCompiled       []glob.Glob                        `json:"-" yaml:"-"`
-	CompiledPaths             map[string]*CompiledPath           `json:"-"`
-	CompiledIgnoreRedirects   []*CompiledRedirect                `json:"-" yaml:"-"`
-	CompiledRedirectAllowList []*CompiledRedirect                `json:"-" yaml:"-"`
-	FS                        embed.FS                           `json:"-"`
-	Logger                    *slog.Logger
+	IgnoreValidation            []string                      `json:"ignoreValidation,omitempty" yaml:"ignoreValidation,omitempty"`
+	ValidationAllowList         []string                      `json:"validationAllowList,omitempty" yaml:"validationAllowList,omitempty"`
+	HARFile                     *harhar.HAR                   `json:"-" yaml:"-"`
+	CompiledPathDelays          map[string]*CompiledPathDelay `json:"-" yaml:"-"`
+	CompiledVariables           map[string]*CompiledVariable  `json:"-" yaml:"-"`
+	Version                     string                        `json:"-" yaml:"-"`
+	StaticPathsCompiled         []glob.Glob                   `json:"-" yaml:"-"`
+	CompiledPaths               map[string]*CompiledPath      `json:"-"`
+	CompiledIgnoreRedirects     []*CompiledRedirect           `json:"-" yaml:"-"`
+	CompiledRedirectAllowList   []*CompiledRedirect           `json:"-" yaml:"-"`
+	CompiledIgnoreValidations   []*CompiledRedirect           `json:"-" yaml:"-"`
+	CompiledValidationAllowList []*CompiledRedirect           `json:"-" yaml:"-"`
+	FS                          embed.FS                      `json:"-"`
+	Logger                      *slog.Logger
 }
 
 func (wtc *WiretapConfiguration) CompilePaths() {
@@ -113,6 +117,26 @@ func (wtc *WiretapConfiguration) CompileRedirectAllowList() {
 			CompiledPath: glob.MustCompile(wtc.ReplaceWithVariables(x)),
 		}
 		wtc.CompiledRedirectAllowList = append(wtc.CompiledRedirectAllowList, compiled)
+	}
+}
+
+func (wtc *WiretapConfiguration) CompileIgnoreValidations() {
+	wtc.CompiledIgnoreValidations = make([]*CompiledRedirect, 0)
+	for _, x := range wtc.IgnoreValidation {
+		compiled := &CompiledRedirect{
+			CompiledPath: glob.MustCompile(wtc.ReplaceWithVariables(x)),
+		}
+		wtc.CompiledIgnoreValidations = append(wtc.CompiledIgnoreValidations, compiled)
+	}
+}
+
+func (wtc *WiretapConfiguration) CompileValidationAllowList() {
+	wtc.CompiledValidationAllowList = make([]*CompiledRedirect, 0)
+	for _, x := range wtc.ValidationAllowList {
+		compiled := &CompiledRedirect{
+			CompiledPath: glob.MustCompile(wtc.ReplaceWithVariables(x)),
+		}
+		wtc.CompiledValidationAllowList = append(wtc.CompiledValidationAllowList, compiled)
 	}
 }
 


### PR DESCRIPTION
This MR adds two configuration options:

- `ignoreValidation`
- `validationAllowList`

Paths that match ignoreValidation will not have wiretap validation run on them, unless they match the validationAllowList.