### PR TITLE
Added a --strict-redirect-location option

### DIFF
--- a/cmd/booted_message.go
+++ b/cmd/booted_message.go
@@ -4,7 +4,6 @@
 package cmd
 
 import (
-	"fmt"
 	"github.com/pb33f/ranch/bus"
 	"github.com/pb33f/ranch/model"
 	"github.com/pb33f/ranch/plank/pkg/server"
@@ -21,13 +20,9 @@ func bootedMessage(wiretapConfig *shared.WiretapConfiguration) {
 			if !seen {
 				seen = true
 				pterm.Println()
-				protocol := "http"
-				if wiretapConfig.CertificateKey != "" && wiretapConfig.Certificate != "" {
-					protocol = "https"
-				}
 
-				b1 := pterm.DefaultBox.WithTitle(pterm.LightMagenta("API Gateway")).Sprint(fmt.Sprintf("%s://localhost:%s", protocol, wiretapConfig.Port))
-				b2 := pterm.DefaultBox.WithTitle(pterm.LightMagenta("Monitor UI")).Sprint(fmt.Sprintf("%s://localhost:%s", protocol, wiretapConfig.MonitorPort))
+				b1 := pterm.DefaultBox.WithTitle(pterm.LightMagenta("API Gateway")).Sprint(wiretapConfig.GetApiGateway())
+				b2 := pterm.DefaultBox.WithTitle(pterm.LightMagenta("Monitor UI")).Sprint(wiretapConfig.GetMonitorUI())
 				b3 := pterm.DefaultBox.WithTitle(pterm.LightMagenta("Static files served from")).Sprint(wiretapConfig.StaticDir)
 
 				var pp *pterm.PanelPrinter

--- a/cmd/root_command.go
+++ b/cmd/root_command.go
@@ -86,6 +86,7 @@ var (
 			hardErrorCode, _ = cmd.Flags().GetInt("hard-validation-code")
 			hardErrorReturnCode, _ = cmd.Flags().GetInt("hard-validation-return-code")
 			streamReport, _ := cmd.Flags().GetBool("stream-report")
+			strictRedirectLocation, _ := cmd.Flags().GetBool("strict-redirect-location")
 
 			portFlag, _ := cmd.Flags().GetString("port")
 			if portFlag != "" {
@@ -186,6 +187,11 @@ var (
 						config.StreamReport = true
 					}
 				}
+				if strictRedirectLocation {
+					if !config.StrictRedirectLocation {
+						config.StrictRedirectLocation = true
+					}
+				}
 
 				if reportFilename != "" {
 					config.ReportFile = reportFilename
@@ -213,6 +219,9 @@ var (
 				}
 				if streamReport {
 					config.StreamReport = true
+				}
+				if strictRedirectLocation {
+					config.StrictRedirectLocation = true
 				}
 				if base != "" {
 					config.Base = base
@@ -357,11 +366,6 @@ var (
 				}
 
 				printLoadedWebsockets(config.WebsocketConfigs)
-			}
-
-			if len(config.ValidationAllowList) > 0 {
-				config.CompileIgnoreValidations()
-				// TODO: add print command
 			}
 
 			if len(config.IgnoreValidation) > 0 {
@@ -658,6 +662,7 @@ func Execute(version, commit, date string, fs embed.FS) {
 	rootCmd.Flags().StringArrayP("har-allow", "j", nil, "Add a path to the HAR allow list, can use arg multiple times")
 	rootCmd.Flags().StringP("report-filename", "f", "wiretap-report.json", "Filename for any headless report generation output")
 	rootCmd.Flags().BoolP("stream-report", "a", false, "Stream violations to report JSON file as they occur (headless mode)")
+	rootCmd.Flags().BoolP("strict-redirect-location", "r", false, "Rewrite the redirect `Location` header on redirect responses to wiretap's API Gateway Host")
 
 	if err := rootCmd.Execute(); err != nil {
 		os.Exit(1)

--- a/daemon/handle_request.go
+++ b/daemon/handle_request.go
@@ -390,15 +390,15 @@ func setStrictLocationHeader(config *shared.WiretapConfiguration, headers map[st
 			if parseErr != nil {
 				config.Logger.Warn(fmt.Sprintf("Unable to parse `Location` header URL: %s", location))
 				newLocations = append(newLocations, location)
-
-				// Check if the target location's host differs from wiretap's host
-			} else if parsedLocation.Host != apiGatewayHost {
+			} else if parsedLocation.Host != apiGatewayHost { // Check if the target location's host differs from wiretap's host
 				parsedLocation.Host = apiGatewayHost
 
 				newLocation := parsedLocation.String()
 				config.Logger.Info(fmt.Sprintf("Rewrote `Location` header from %s to %s", location, newLocation))
 
 				newLocations = append(newLocations, newLocation)
+			} else { // Otherwise, we need to re-add the old location
+				newLocations = append(newLocations, location)
 			}
 
 		}

--- a/daemon/handle_request.go
+++ b/daemon/handle_request.go
@@ -390,7 +390,7 @@ func setStrictLocationHeader(config *shared.WiretapConfiguration, headers map[st
 			if parseErr != nil {
 				config.Logger.Warn(fmt.Sprintf("Unable to parse `Location` header URL: %s", location))
 				newLocations = append(newLocations, location)
-			} else if parsedLocation.Host != apiGatewayHost { // Check if the target location's host differs from wiretap's host
+			} else if parsedLocation.Host != "" && parsedLocation.Host != apiGatewayHost { // Check if the target location's host differs from wiretap's host
 				parsedLocation.Host = apiGatewayHost
 
 				newLocation := parsedLocation.String()

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/lucasjones/reggen v0.0.0-20200904144131-37ba4fa293bb // indirect
 	github.com/pb33f/harhar v0.0.0-20240111233202-e393c2a39a60
 	github.com/pb33f/libopenapi v0.15.14
-	github.com/pb33f/libopenapi-validator v0.0.48
+	github.com/pb33f/libopenapi-validator v0.0.50
 	github.com/pb33f/ranch v0.4.0
 	github.com/pterm/pterm v0.12.76
 	golang.org/x/exp v0.0.0-20240213143201-ec583247a57a // indirect

--- a/go.sum
+++ b/go.sum
@@ -147,6 +147,7 @@ github.com/pb33f/libopenapi-validator v0.0.44 h1:z7SVS6mMVv/f4V73e9H1UCiWrMzMg2u
 github.com/pb33f/libopenapi-validator v0.0.44/go.mod h1:kU1JYyXIRlpmsWx3NkL+drNNttLADMgdaNzJgXDhec0=
 github.com/pb33f/libopenapi-validator v0.0.45 h1:UxTeaxwi2URM9RQlXNbke3zeibijz2kA28T3zVhmp/A=
 github.com/pb33f/libopenapi-validator v0.0.45/go.mod h1:kU1JYyXIRlpmsWx3NkL+drNNttLADMgdaNzJgXDhec0=
+github.com/pb33f/libopenapi-validator v0.0.48/go.mod h1:kU1JYyXIRlpmsWx3NkL+drNNttLADMgdaNzJgXDhec0=
 github.com/pb33f/ranch v0.4.0 h1:fve9Lozc9m0IGkygWD3EFkBtbRua+2gyi9yxYHvufh4=
 github.com/pb33f/ranch v0.4.0/go.mod h1:LfZITTWTb1quxakzKr2RErDdSGOrxV/dpai9DK4Aa6k=
 github.com/pelletier/go-toml/v2 v2.1.0 h1:FnwAJ4oYMvbT/34k9zzHuZNrhlz48GB3/s6at6/MHO4=

--- a/shared/config.go
+++ b/shared/config.go
@@ -13,54 +13,55 @@ import (
 )
 
 type WiretapConfiguration struct {
-	Contract                    string                        `json:"-" yaml:"-"`
-	RedirectHost                string                        `json:"redirectHost,omitempty" yaml:"redirectHost,omitempty"`
-	RedirectPort                string                        `json:"redirectPort,omitempty" yaml:"redirectPort,omitempty"`
-	RedirectBasePath            string                        `json:"redirectBasePath,omitempty" yaml:"redirectBasePath,omitempty"`
-	RedirectProtocol            string                        `json:"redirectProtocol,omitempty" yaml:"redirectProtocol,omitempty"`
-	RedirectURL                 string                        `json:"redirectURL,omitempty" yaml:"redirectURL,omitempty"`
-	Port                        string                        `json:"port,omitempty" yaml:"port,omitempty"`
-	MonitorPort                 string                        `json:"monitorPort,omitempty" yaml:"monitorPort,omitempty"`
-	WebSocketHost               string                        `json:"webSocketHost,omitempty" yaml:"webSocketHost,omitempty"`
-	WebSocketPort               string                        `json:"webSocketPort,omitempty" yaml:"webSocketPort,omitempty"`
-	GlobalAPIDelay              int                           `json:"globalAPIDelay,omitempty" yaml:"globalAPIDelay,omitempty"`
-	StaticDir                   string                        `json:"staticDir,omitempty" yaml:"staticDir,omitempty"`
-	StaticIndex                 string                        `json:"staticIndex,omitempty" yaml:"staticIndex,omitempty"`
-	PathConfigurations          map[string]*WiretapPathConfig `json:"paths,omitempty" yaml:"paths,omitempty"`
-	Headers                     *WiretapHeaderConfig          `json:"headers,omitempty" yaml:"headers,omitempty"`
-	StaticPaths                 []string                      `json:"staticPaths,omitempty" yaml:"staticPaths,omitempty"`
-	Variables                   map[string]string             `json:"variables,omitempty" yaml:"variables,omitempty"`
-	Spec                        string                        `json:"contract,omitempty" yaml:"contract,omitempty"`
-	Certificate                 string                        `json:"certificate,omitempty" yaml:"certificate,omitempty"`
-	CertificateKey              string                        `json:"certificateKey,omitempty" yaml:"certificateKey,omitempty"`
-	HardErrors                  bool                          `json:"hardValidation,omitempty" yaml:"hardValidation,omitempty"`
-	HardErrorCode               int                           `json:"hardValidationCode,omitempty" yaml:"hardValidationCode,omitempty"`
-	HardErrorReturnCode         int                           `json:"hardValidationReturnCode,omitempty" yaml:"hardValidationReturnCode,omitempty"`
-	PathDelays                  map[string]int                `json:"pathDelays,omitempty" yaml:"pathDelays,omitempty"`
-	MockMode                    bool                          `json:"mockMode,omitempty" yaml:"mockMode,omitempty"`
-	MockModePretty              bool                          `json:"mockModePretty,omitempty" yaml:"mockModePretty,omitempty"`
-	Base                        string                        `json:"base,omitempty" yaml:"base,omitempty"`
-	HAR                         string                        `json:"har,omitempty" yaml:"har,omitempty"`
-	HARValidate                 bool                          `json:"harValidate,omitempty" yaml:"harValidate,omitempty"`
-	HARPathAllowList            []string                      `json:"harPathAllowList,omitempty" yaml:"harPathAllowList,omitempty"`
-	StreamReport                bool                          `json:"streamReport,omitempty" yaml:"streamReport,omitempty"`
-	ReportFile                  string                        `json:"reportFilename,omitempty" yaml:"reportFilename,omitempty"`
-	IgnoreRedirects             []string                      `json:"ignoreRedirects,omitempty" yaml:"ignoreRedirects,omitempty"`
-	RedirectAllowList           []string                      `json:"redirectAllowList,omitempty" yaml:"redirectAllowList,omitempty"`
-	WebsocketConfigs          map[string]*WiretapWebsocketConfig `json:"websockets" yaml:"websockets"`
-	IgnoreValidation            []string                      `json:"ignoreValidation,omitempty" yaml:"ignoreValidation,omitempty"`
-	ValidationAllowList         []string                      `json:"validationAllowList,omitempty" yaml:"validationAllowList,omitempty"`
-	HARFile                     *harhar.HAR                   `json:"-" yaml:"-"`
-	CompiledPathDelays          map[string]*CompiledPathDelay `json:"-" yaml:"-"`
-	CompiledVariables           map[string]*CompiledVariable  `json:"-" yaml:"-"`
-	Version                     string                        `json:"-" yaml:"-"`
-	StaticPathsCompiled         []glob.Glob                   `json:"-" yaml:"-"`
-	CompiledPaths               map[string]*CompiledPath      `json:"-"`
-	CompiledIgnoreRedirects     []*CompiledRedirect           `json:"-" yaml:"-"`
-	CompiledRedirectAllowList   []*CompiledRedirect           `json:"-" yaml:"-"`
-	CompiledIgnoreValidations   []*CompiledRedirect           `json:"-" yaml:"-"`
-	CompiledValidationAllowList []*CompiledRedirect           `json:"-" yaml:"-"`
-	FS                          embed.FS                      `json:"-"`
+	Contract                    string                             `json:"-" yaml:"-"`
+	RedirectHost                string                             `json:"redirectHost,omitempty" yaml:"redirectHost,omitempty"`
+	RedirectPort                string                             `json:"redirectPort,omitempty" yaml:"redirectPort,omitempty"`
+	RedirectBasePath            string                             `json:"redirectBasePath,omitempty" yaml:"redirectBasePath,omitempty"`
+	RedirectProtocol            string                             `json:"redirectProtocol,omitempty" yaml:"redirectProtocol,omitempty"`
+	RedirectURL                 string                             `json:"redirectURL,omitempty" yaml:"redirectURL,omitempty"`
+	Port                        string                             `json:"port,omitempty" yaml:"port,omitempty"`
+	MonitorPort                 string                             `json:"monitorPort,omitempty" yaml:"monitorPort,omitempty"`
+	WebSocketHost               string                             `json:"webSocketHost,omitempty" yaml:"webSocketHost,omitempty"`
+	WebSocketPort               string                             `json:"webSocketPort,omitempty" yaml:"webSocketPort,omitempty"`
+	GlobalAPIDelay              int                                `json:"globalAPIDelay,omitempty" yaml:"globalAPIDelay,omitempty"`
+	StaticDir                   string                             `json:"staticDir,omitempty" yaml:"staticDir,omitempty"`
+	StaticIndex                 string                             `json:"staticIndex,omitempty" yaml:"staticIndex,omitempty"`
+	PathConfigurations          map[string]*WiretapPathConfig      `json:"paths,omitempty" yaml:"paths,omitempty"`
+	Headers                     *WiretapHeaderConfig               `json:"headers,omitempty" yaml:"headers,omitempty"`
+	StaticPaths                 []string                           `json:"staticPaths,omitempty" yaml:"staticPaths,omitempty"`
+	Variables                   map[string]string                  `json:"variables,omitempty" yaml:"variables,omitempty"`
+	Spec                        string                             `json:"contract,omitempty" yaml:"contract,omitempty"`
+	Certificate                 string                             `json:"certificate,omitempty" yaml:"certificate,omitempty"`
+	CertificateKey              string                             `json:"certificateKey,omitempty" yaml:"certificateKey,omitempty"`
+	HardErrors                  bool                               `json:"hardValidation,omitempty" yaml:"hardValidation,omitempty"`
+	HardErrorCode               int                                `json:"hardValidationCode,omitempty" yaml:"hardValidationCode,omitempty"`
+	HardErrorReturnCode         int                                `json:"hardValidationReturnCode,omitempty" yaml:"hardValidationReturnCode,omitempty"`
+	PathDelays                  map[string]int                     `json:"pathDelays,omitempty" yaml:"pathDelays,omitempty"`
+	MockMode                    bool                               `json:"mockMode,omitempty" yaml:"mockMode,omitempty"`
+	MockModePretty              bool                               `json:"mockModePretty,omitempty" yaml:"mockModePretty,omitempty"`
+	Base                        string                             `json:"base,omitempty" yaml:"base,omitempty"`
+	HAR                         string                             `json:"har,omitempty" yaml:"har,omitempty"`
+	HARValidate                 bool                               `json:"harValidate,omitempty" yaml:"harValidate,omitempty"`
+	HARPathAllowList            []string                           `json:"harPathAllowList,omitempty" yaml:"harPathAllowList,omitempty"`
+	StreamReport                bool                               `json:"streamReport,omitempty" yaml:"streamReport,omitempty"`
+	ReportFile                  string                             `json:"reportFilename,omitempty" yaml:"reportFilename,omitempty"`
+	IgnoreRedirects             []string                           `json:"ignoreRedirects,omitempty" yaml:"ignoreRedirects,omitempty"`
+	RedirectAllowList           []string                           `json:"redirectAllowList,omitempty" yaml:"redirectAllowList,omitempty"`
+	WebsocketConfigs            map[string]*WiretapWebsocketConfig `json:"websockets" yaml:"websockets"`
+	IgnoreValidation            []string                           `json:"ignoreValidation,omitempty" yaml:"ignoreValidation,omitempty"`
+	ValidationAllowList         []string                           `json:"validationAllowList,omitempty" yaml:"validationAllowList,omitempty"`
+	StrictRedirectLocation      bool                               `json:"strictRedirectLocation,omitempty" yaml:"strictRedirectLocation,omitempty"`
+	HARFile                     *harhar.HAR                        `json:"-" yaml:"-"`
+	CompiledPathDelays          map[string]*CompiledPathDelay      `json:"-" yaml:"-"`
+	CompiledVariables           map[string]*CompiledVariable       `json:"-" yaml:"-"`
+	Version                     string                             `json:"-" yaml:"-"`
+	StaticPathsCompiled         []glob.Glob                        `json:"-" yaml:"-"`
+	CompiledPaths               map[string]*CompiledPath           `json:"-"`
+	CompiledIgnoreRedirects     []*CompiledRedirect                `json:"-" yaml:"-"`
+	CompiledRedirectAllowList   []*CompiledRedirect                `json:"-" yaml:"-"`
+	CompiledIgnoreValidations   []*CompiledRedirect                `json:"-" yaml:"-"`
+	CompiledValidationAllowList []*CompiledRedirect                `json:"-" yaml:"-"`
+	FS                          embed.FS                           `json:"-"`
 	Logger                      *slog.Logger
 }
 
@@ -148,6 +149,28 @@ func (wtc *WiretapConfiguration) ReplaceWithVariables(input string) string {
 		}
 	}
 	return input
+}
+
+func (wtc *WiretapConfiguration) GetHttpProtocol() string {
+	protocol := "http"
+
+	if wtc.CertificateKey != "" && wtc.Certificate != "" {
+		protocol = "https"
+	}
+
+	return protocol
+}
+
+func (wtc *WiretapConfiguration) GetApiGateway() string {
+	return fmt.Sprintf("%s://%s", wtc.GetHttpProtocol(), wtc.GetApiGatewayHost())
+}
+
+func (wtc *WiretapConfiguration) GetApiGatewayHost() string {
+	return fmt.Sprintf("localhost:%s", wtc.Port)
+}
+
+func (wtc *WiretapConfiguration) GetMonitorUI() string {
+	return fmt.Sprintf("%s://localhost:%s", wtc.GetHttpProtocol(), wtc.MonitorPort)
 }
 
 type WiretapWebsocketConfig struct {


### PR DESCRIPTION
Added a --strict-redirect-location option; if enabled wiretap will rewrite all `Location` header hosts to wiretap's api gateway host