### PR TITLE
Check if mock is not nil before writing response

### DIFF
--- a/daemon/handle_mock.go
+++ b/daemon/handle_mock.go
@@ -90,9 +90,12 @@ func (ws *WiretapService) handleMockRequest(
 
 	// if the mock is empty
 	request.HttpResponseWriter.WriteHeader(mockStatus)
+	if mock == nil {
+		return
+	}
+
 	_, errs := request.HttpResponseWriter.Write(mock)
 	if errs != nil {
 		panic(errs)
 	}
-	return
 }


### PR DESCRIPTION
This pull request introduces a safeguard in the event that the `mock` object is nil. This will fix cases where the response is HTTP 204 with no response body.

```
http: panic serving [::1]:54949: http: request method or response status code does not allow body
goroutine 5165 [running]:
net/http.(*conn).serve.func1()
        /usr/local/go/src/net/http/server.go:1898 +0x118
panic({0x104071000?, 0x1400031fde0?})
        /usr/local/go/src/runtime/panic.go:770 +0xf0
github.com/pb33f/wiretap/daemon.(*WiretapService).handleMockRequest(0x140010aa820, 0x140015fc240, 0x140003a0908, 0x140014d4fc0)
        /Users/martinsirbe/dev/go/src/github.com/pb33f/wiretap/daemon/handle_mock.go:95 +0xf3c
github.com/pb33f/wiretap/daemon.(*WiretapService).handleHttpRequest(0x140010aa820, 0x140015fc240)
        /Users/martinsirbe/dev/go/src/github.com/pb33f/wiretap/daemon/handle_request.go:137 +0x718
github.com/pb33f/wiretap/daemon.(*WiretapService).HandleHttpRequest(0x140010aa820, 0x140015fc240)
        /Users/martinsirbe/dev/go/src/github.com/pb33f/wiretap/daemon/wiretap_service.go:98 +0x24
github.com/pb33f/wiretap/cmd.handleHttpTraffic.func1.1({0x10421d9d0, 0x140011c7450}, 0x140014d4ea0)
        /Users/martinsirbe/dev/go/src/github.com/pb33f/wiretap/cmd/handle_http_traffic.go:27 +0x198
net/http.HandlerFunc.ServeHTTP(0x14000982210, {0x10421d9d0, 0x140011c7450}, 0x140014d4ea0)
        /usr/local/go/src/net/http/server.go:2166 +0x40
net/http.(*ServeMux).ServeHTTP(0x1400128e9c0, {0x10421d9d0, 0x140011c7450}, 0x140014d4ea0)
        /usr/local/go/src/net/http/server.go:2683 +0x29c
github.com/gorilla/handlers.CompressHandlerLevel.func1({0x10421d9d0, 0x140011c7450}, 0x140014d4ea0)
        /Users/martinsirbe/dev/go/pkg/mod/github.com/gorilla/handlers@v1.4.2/compress.go:148 +0xc4c
net/http.HandlerFunc.ServeHTTP(0x1400103e080, {0x10421db50, 0x14000216000}, 0x140014d4ea0)
        /usr/local/go/src/net/http/server.go:2166 +0x40
net/http.serverHandler.ServeHTTP({0x1400152a1e0}, {0x10421db50, 0x14000216000}, 0x140014d4ea0)
        /usr/local/go/src/net/http/server.go:3137 +0x2b0
net/http.(*conn).serve(0x14000e4ed80, {0x10421f678, 0x140011c7310})
        /usr/local/go/src/net/http/server.go:2039 +0x15f8
created by net/http.(*Server).Serve in goroutine 7620
        /usr/local/go/src/net/http/server.go:3285 +0x88c
```