### PR TITLE
v0.1.11

### DIFF
--- a/mock/mock_engine.go
+++ b/mock/mock_engine.go
@@ -348,6 +348,11 @@ func (rme *ResponseMockEngine) runWorkflow(request *http.Request) ([]byte, int, 
 		), 200, err
 	}
 
+	// check for wiretap-status-code in header and override the code, regardless of what was found in the spec.
+	if statusCode := request.Header.Get("wiretap-status-code"); statusCode != "" {
+		c, _ = strconv.Atoi(statusCode)
+	}
+
 	return mock, c, nil
 }
 


### PR DESCRIPTION
setting a header with `wiretap-status-code` and a status code, will automatically override any status code set by the OpenAPI spec when running in mock mode.

Only works for successful mocks, any errors/failed mock requests will return the existing error codes.

Addresses feature request #89