### PR TITLE
Fix Mock Handling for 204 Success Responses

### DIFF
--- a/mock/mock_engine.go
+++ b/mock/mock_engine.go
@@ -316,6 +316,11 @@ func (rme *ResponseMockEngine) runWorkflow(request *http.Request) ([]byte, int, 
 		mt, noMT = rme.findBestMediaTypeMatch(operation, request, []string{lo})
 	}
 
+	c, _ := strconv.Atoi(lo)
+	if c == http.StatusNoContent {
+		return nil, c, nil
+	}
+
 	if mt == nil && noMT {
 		mtString := rme.extractMediaTypeHeader(request)
 		return rme.buildError(
@@ -336,7 +341,6 @@ func (rme *ResponseMockEngine) runWorkflow(request *http.Request) ([]byte, int, 
 			"build_mock_error",
 		), 422, mockErr
 	}
-	c, _ := strconv.Atoi(lo)
 
 	if len(mock) == 0 {
 		return rme.buildError(


### PR DESCRIPTION
This PR updates the mock response handling logic to correctly recognize and process HTTP 204 status codes without expecting a response body.

Currently, the mock server handles mocked responses for requests that are expected to return an HTTP 204 status code. The core issue lies in the service treating HTTP 204 responses as if they should return content.

For more details, please see the `TestNewMockEngine_UseExamples_204_Response` test case.