### PR TITLE
Wiretap doesn't handle multi-value header keys correctly when writing…

### DIFF
--- a/daemon/handle_request.go
+++ b/daemon/handle_request.go
@@ -200,7 +200,13 @@ func (ws *WiretapService) handleHttpRequest(request *model.Request) {
 	// write headers
 	for k, v := range headers {
 		for _, j := range v {
-			request.HttpResponseWriter.Header().Set(k, fmt.Sprint(j))
+			responseHeaders := request.HttpResponseWriter.Header()
+
+			if responseHeaders.Get(k) == "" {
+				request.HttpResponseWriter.Header().Set(k, fmt.Sprint(j))
+			} else {
+				request.HttpResponseWriter.Header().Add(k, fmt.Sprint(j))
+			}
 		}
 	}
 	config.Logger.Info("[wiretap] request completed", "url", request.HttpRequest.URL.String(), "code", returnedResponse.StatusCode)

--- a/daemon/handle_request.go
+++ b/daemon/handle_request.go
@@ -203,9 +203,9 @@ func (ws *WiretapService) handleHttpRequest(request *model.Request) {
 			responseHeaders := request.HttpResponseWriter.Header()
 
 			if responseHeaders.Get(k) == "" {
-				request.HttpResponseWriter.Header().Set(k, fmt.Sprint(j))
+				responseHeaders.Set(k, fmt.Sprint(j))
 			} else {
-				request.HttpResponseWriter.Header().Add(k, fmt.Sprint(j))
+				responseHeaders.Add(k, fmt.Sprint(j))
 			}
 		}
 	}


### PR DESCRIPTION
Wiretap currently doesn't handle multi-value headers correctly. It currently only writes back the last value in any header array.

To fix this, we need to set the initial value, and then add new values afterwards.