### PR TITLE
Added nill check for path configuration options. Fixes panic thrown by root.

### DIFF
--- a/cmd/root_command.go
+++ b/cmd/root_command.go
@@ -346,7 +346,7 @@ var (
 			}
 
 			// paths
-			if config.PathConfigurations.Len() > 0 || len(config.StaticPaths) > 0 || len(config.HARPathAllowList) > 0 || len(config.IgnorePathRewrite) > 0 {
+			if config.PathConfigurations != nil && config.PathConfigurations.Len() > 0 || len(config.StaticPaths) > 0 || len(config.HARPathAllowList) > 0 || len(config.IgnorePathRewrite) > 0 {
 				config.CompilePaths()
 				if len(config.IgnorePathRewrite) > 0 {
 					printLoadedIgnorePathRewrite(config.IgnorePathRewrite)


### PR DESCRIPTION
was throwing a panic when no config was used. A recent addition to the configuration, needs a nil check when booting.