### PR TITLE
OPENAPI: the rewrite header key formatting is wrong in code

### DIFF
--- a/config/paths.go
+++ b/config/paths.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	PascalCaseRewriteIdHeader = "Rewriteid"
-	SnakeCaseRewriteIdHeader  = "rewrite_id"
+	SnakeCaseRewriteIdHeader  = "Rewrite_id"
 	KebabCaseRewriteIdHeader  = "Rewrite-Id"
 )
 
@@ -119,12 +119,17 @@ func getRewriteIdHeaderValues(req *http.Request) ([]string, bool) {
 
 	// Let's now try to ignore case ; this may produce collisions if a user has two headers with similar keys,
 	// but different capitalization. This is okay, as this is a last ditch effort to find any possible match
-	var loweredHeaders = make(http.Header)
+	loweredHeaders := map[string][]string{}
 
 	for headerKey, headerValues := range req.Header {
-		for _, headerValue := range headerValues {
-			loweredHeaders.Set(strings.ToLower(headerKey), headerValue)
+		loweredKey := strings.ToLower(headerKey)
+
+		if _, ok := loweredHeaders[loweredKey]; ok {
+			loweredHeaders[loweredKey] = append(loweredHeaders[loweredKey], headerValues...)
+		} else {
+			loweredHeaders[loweredKey] = headerValues
 		}
+
 	}
 
 	for _, possibleHeaderKey := range rewriteIdHeaders {
@@ -135,7 +140,7 @@ func getRewriteIdHeaderValues(req *http.Request) ([]string, bool) {
 
 	}
 
-	return nil, false
+	return []string{}, false
 }
 
 func FindPathWithRewriteId(paths []*shared.WiretapPathConfig, req *http.Request) *shared.WiretapPathConfig {

--- a/config/paths_test.go
+++ b/config/paths_test.go
@@ -494,3 +494,96 @@ func TestValidationAllowList_NoPathsRegistered(t *testing.T) {
 	assert.False(t, ignore)
 
 }
+
+func TestGetRewriteHeaderValues(t *testing.T) {
+
+	expectedValue := []string{"ExpectedValue"}
+
+	requestList := []*http.Request{
+		{
+			Header: http.Header{
+				"Rewriteid":    expectedValue,
+				"Other-Header": []string{"another header"},
+				"other-header": []string{"another another header"},
+			},
+		},
+		{
+			Header: http.Header{
+				"Rewrite-Id":   expectedValue,
+				"Other-Header": []string{"another header"},
+				"other-header": []string{"another another header"},
+			},
+		},
+		{
+			Header: http.Header{
+				"Rewrite_id":   expectedValue,
+				"Other-Header": []string{"another header"},
+				"other-header": []string{"another another header"},
+			},
+		},
+		{
+			Header: http.Header{
+				"RewriteId":    expectedValue,
+				"Other-Header": []string{"another header"},
+				"other-header": []string{"another another header"},
+			},
+		},
+		{
+			Header: http.Header{
+				"RewrIte-Id":   expectedValue,
+				"Other-Header": []string{"another header"},
+				"other-header": []string{"another another header"},
+			},
+		},
+		{
+			Header: http.Header{
+				"rewriteid":    expectedValue,
+				"Other-Header": []string{"another header"},
+				"other-header": []string{"another another header"},
+			},
+		},
+		{
+			Header: http.Header{
+				"rewrite-id":   expectedValue,
+				"Other-Header": []string{"another header"},
+				"other-header": []string{"another another header"},
+			},
+		},
+		{
+			Header: http.Header{
+				"rewrite_id":   expectedValue,
+				"Other-Header": []string{"another header"},
+				"other-header": []string{"another another header"},
+			},
+		},
+	}
+
+	for _, request := range requestList {
+		actualValue, found := getRewriteIdHeaderValues(request)
+		assert.Equal(t, expectedValue, actualValue)
+		assert.True(t, found)
+	}
+
+}
+
+func TestGetRewriteHeaderValues_MissingHeader(t *testing.T) {
+
+	requestList := []*http.Request{
+		{
+			Header: http.Header{
+				"Other-Header": []string{"another header"},
+				"other-header": []string{"another another header"},
+			},
+		},
+		{
+			Header: http.Header{},
+		},
+	}
+
+	for _, request := range requestList {
+		actualValue, found := getRewriteIdHeaderValues(request)
+		assert.Equal(t, []string{}, actualValue)
+		assert.False(t, found)
+	}
+
+}


### PR DESCRIPTION
There are multiple possible formatting possibilities for header values.

This MR ensures that a variety of header formatting methods are supported for the RewriteId feature.