### PR TITLE
fix: also consider Accept header in addition to Content-Type 

### DIFF
--- a/mock/mock_engine.go
+++ b/mock/mock_engine.go
@@ -160,7 +160,14 @@ func (rme *ResponseMockEngine) extractMediaTypeHeader(request *http.Request) str
 	if mediaTypeSting == "" {
 		mediaTypeSting = contentType // anything?
 	}
+	
 	if mediaTypeSting == "" {
+		// Check the Accept header for a content type
+		contentType = request.Header.Get("Accept")
+		mediaTypeSting, _, _ = helpers.ExtractContentType(contentType)
+	}
+	
+	if (mediaTypeSting == "") {
 		mediaTypeSting = "application/json" // default
 	}
 

--- a/mock/mock_engine_test.go
+++ b/mock/mock_engine_test.go
@@ -1103,17 +1103,26 @@ components:
 	assert.Equal(t, "robocop", decoded["name"])
 	assert.Equal(t, "perhaps the best cyberpunk movie ever made.", decoded["description"])
 
-	// Now see if html will work
+	// Now see if html will work with preferred header for second html example
 	request, _ = http.NewRequest(http.MethodGet, "https://api.pb33f.io/test", nil)
-	request.Header.Set(helpers.Preferred, "happyHtmlDays")
+	request.Header.Set(helpers.Preferred, "robocopInHtml")
 	request.Header.Set("Content-Type", "text/html")
 
 	b, status, err = me.GenerateResponse(request)
 
 	assert.NoError(t, err)
 	assert.Equal(t, 200, status)
-	assert.Equal(t, "<!DOCTYPE html><html lang=\"en\"><body><h1>Happy Days</h1</body></html>", string(b[:]))
+	assert.Equal(t, "<!DOCTYPE html><html lang=\"en\"><body><h1>Robo cop</h1</body></html>", string(b[:]))
 
+	// Now see if html will work w/ Accept header and no preferred
+	request, _ = http.NewRequest(http.MethodGet, "https://api.pb33f.io/test", nil)
+	request.Header.Set("Accept", "text/html")
+
+	b, status, err = me.GenerateResponse(request)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 200, status)
+	assert.Equal(t, "<!DOCTYPE html><html lang=\"en\"><body><h1>Happy Days</h1</body></html>", string(b[:]))
 }
 
 // https://github.com/pb33f/wiretap/issues/83


### PR DESCRIPTION
Noticed that the `Accept` header was not considered when wiretap was selecting from possible mock responses, while the `Content-Type` header was. 

This change makes wiretap consider the client's Accept header (as a very basic form of mocking [content negotation](https://developer.mozilla.org/en-US/docs/Web/HTTP/Content_negotiation)) when deciding what if any example should be used for a mock response.

