### PR TITLE
Update docker build

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -99,10 +99,13 @@ jobs:
           images: |
             pb33f/wiretap
             ghcr.io/${{ github.repository }}
-
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        
       - name: Build and push Docker images
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v6
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: pb33f/wiretap:latest, pb33f/wiretap:${{ github.event.client_payload.new-tag }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,6 +43,6 @@ RUN echo "I am running on $TARGETPLATFORM, was built on $BUILDPLATFORM" > /log
 # copy only the built binary
 COPY --from=gobuilder /wiretap /wiretap
 
-ENV PATH=$PATH:/work/bin
+ENV PATH=$PATH:/
 
 ENTRYPOINT ["wiretap"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ RUN echo "I am building go for GOOS:$TARGETOS, GOARCH:$TARGETARCH" > /log
 RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go mod download && go mod verify
 RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -ldflags="-w -s" -v -o /wiretap wiretap.go
 
-FROM golang:1.23-alpine AS runner
+FROM alpine:3.20.3 AS runner
 
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,9 @@
-FROM node:20-bookworm-slim as builder
+FROM node:20-bookworm-slim AS uibuilder
+
+ARG TARGETOS
+ARG TARGETARCH
+
+RUN echo "I am building ui for OS:$TARGETOS, ARCH:$TARGETARCH" > /log
 
 # set up ui build
 RUN mkdir -p /wt_build
@@ -11,18 +16,33 @@ WORKDIR /wt_build/ui
 RUN yarn install
 RUN yarn build
 
-FROM golang:1.23-bookworm
+FROM golang:1.23-bookworm AS gobuilder
+
+ARG TARGETOS
+ARG TARGETARCH
 
 WORKDIR /work
 
 # copy ui build from previous stage
-COPY --from=builder /wt_build/ui ./ui
+COPY --from=uibuilder /wt_build/ui/dist ./ui/dist
 
 COPY . ./
 
-RUN go mod download && go mod verify
-RUN go build -ldflags="-w -s" -v -o /wiretap wiretap.go
+RUN echo "I am building go for GOOS:$TARGETOS, GOARCH:$TARGETARCH" > /log
 
-ENV PATH=$PATH:/
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go mod download && go mod verify
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -ldflags="-w -s" -v -o /wiretap wiretap.go
+
+FROM golang:1.23-alpine AS runner
+
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+
+RUN echo "I am running on $TARGETPLATFORM, was built on $BUILDPLATFORM" > /log
+
+# copy only the built binary
+COPY --from=gobuilder /wiretap /wiretap
+
+ENV PATH=$PATH:/work/bin
 
 ENTRYPOINT ["wiretap"]


### PR DESCRIPTION
- Adds muti-platform support to go commands
- Changed to three stage build so ui and go build are mostly parallel and final stage does not have any of the files used for building.
- Tweaked pubish github workflow to minimally publish containers for two platforms, `linux/amd64` and `linux/arm64`