### PR TITLE
Minor json correction in static mock doc

### DIFF
--- a/static-mock/README.md
+++ b/static-mock/README.md
@@ -187,7 +187,7 @@ The `--static-mock-dir` should point to a directory that contains the following 
     "header": {
       "something-header": "test-ok"
     },
-    "bodyJsonFilename": "test.json",
+    "bodyJsonFilename": "test.json"
   }
 }
 ```


### PR DESCRIPTION
The static mock documentation included an invalid example JSON document (get-test-mock.json), with a trailing comma where it shouldn't have been. I've removed it to make it easier for others to try out the new feature.