### PR TITLE
Static mock directory feature repair

### DIFF
--- a/cmd/root_command.go
+++ b/cmd/root_command.go
@@ -276,7 +276,7 @@ var (
 				return nil
 			}
 
-			if !mockMode && redirectURL == "" && harFlag == "" {
+			if !(mockMode || len(config.MockModeList) > 0) && len(config.StaticMockDir) == 0 && len(staticMockDir) == 0 && redirectURL == "" && harFlag == "" {
 				pterm.Println()
 				pterm.Error.Println("No redirect URL provided. " +
 					"Please provide a URL to redirect API traffic to using the --url or -u flags.")

--- a/static-mock/README.md
+++ b/static-mock/README.md
@@ -187,7 +187,7 @@ The `--static-mock-dir` should point to a directory that contains the following 
     "header": {
       "something-header": "test-ok"
     },
-    "bodyJsonFilename": "test.json",
+    "bodyJsonFilename": "test.json"
   }
 }
 ```


### PR DESCRIPTION
Change 1:
The static mock documentation included an invalid example JSON document (get-test-mock.json), with a trailing comma where it shouldn't have been. I've removed it to make it easier for others to try out the new feature.

Change 2:
The -u argument error checking considered only the mockDir feature. It hadn't been updated to also check for staticMockDir. This error handing has been adjusted accordingly.

Notes:
- the current argument error checking makes it unclear whether mockDir or config.MockDir is the master checked when evaluating configuration. e.g. The current code might ignore the mockDir value in the configuration file when doing a number of its argument error checks. As this convention was unclear I've gone with the overkill approach and checked that neither the command line argument nor the config file have specified a static mock dir. This is safe but inconsistent with the other checks. It is worth checking the argument error handling to make sure it copes with both ways of supplying settings.
- while the feature now activates, following the example in the documentation still doesn't seem to work. e.g. `curl http://localhost:9090/test` resulted in an infinite loop of mock requests (when checked through the monitor UI), or one time it returned a 500 error. It is possible this is something to do with me not setting up my dev environment correctly, so please check this on your end. More changes may be required for this feature to work correctly.
