### PR TITLE
Static mock docs updated to reflect usage and include a complete working example

### DIFF
--- a/static-mock/README.md
+++ b/static-mock/README.md
@@ -21,7 +21,7 @@ To enable static mocking, you need to set the `--static-mock-dir` argument to a 
 
 Example:
 ```bash
-wiretap --static-mock-dir /path/to/mocks
+wiretap --static-mock-dir /path/to/mocks -u http://some.api-host-outhere.some-domain.com
 ```
 
 When this path is set, Wiretap will expect mock definitions and response body JSON files in the following structure:
@@ -200,7 +200,31 @@ The `--static-mock-dir` should point to a directory that contains the following 
 }
 ```
 
-With this configuration, when Wiretap receives a `GET` request to `/test`, it will respond with the content of `test.json`.
+4. **Run wiretap**:
+
+```bash
+wiretap -u "http://localhost:8089" --static-mock-dir "/path/to/mocks" --port 80
+```
+
+Note: Any requests not matching a static mock will be proxied to the URL specified by the `-u` parameter.
+
+5. **Make a request via curl**:
+
+```bash
+curl --location --request GET 'http://localhost/test?test=ok&arr=1&arr=2' \
+--header 'Content-Type: application/json' \
+--data '{
+    "test": "ok"
+}'
+```
+
+With this configuration, when Wiretap receives a `GET` request to `/test`, it will respond with the following JSON which represents the content of `test.json` after substituting the appropriate query parameter value:
+
+```json
+{
+        "test": "2"
+}
+```
 
 ## Notes
 

--- a/static-mock/README.md
+++ b/static-mock/README.md
@@ -157,7 +157,7 @@ The `--static-mock-dir` should point to a directory that contains the following 
 1. **Directory Structure:**
 
 ```
-/mocks/
+./mocks/
   ├── mock-definitions/
   │     ├── get-test-mock.json
   └── body-jsons/
@@ -203,7 +203,7 @@ The `--static-mock-dir` should point to a directory that contains the following 
 4. **Run wiretap**:
 
 ```bash
-wiretap -u "http://localhost:8089" --static-mock-dir "/path/to/mocks" --port 80
+wiretap -u "http://localhost:8089" --static-mock-dir ./mocks --port 80
 ```
 
 Note: Any requests not matching a static mock will be proxied to the URL specified by the `-u` parameter.

--- a/static-mock/README.md
+++ b/static-mock/README.md
@@ -187,7 +187,7 @@ The `--static-mock-dir` should point to a directory that contains the following 
     "header": {
       "something-header": "test-ok"
     },
-    "bodyJsonFilename": "test.json",
+    "bodyJsonFilename": "test.json"
   }
 }
 ```


### PR DESCRIPTION
The static mock documentation did not reflect the feature's expectations and behaviour explained in issue #153 .

The documentation has been updated to:
- include a valid command line as the first example of how to use the feature (i.e. added `-u` parameter)
- fix an invalid example JSON document (get-test-mock.json), which had a trailing comma where it shouldn't have been. 
- extended the example to include the wiretap and curl commands to test the example, added the expected response JSON document, and adjusted the directory structure to be relative to whereever the user is running the command.

Hopefully this is enough of a change that users can have a successful first test of the feature purely by following the steps laid out in the example.

CC @akash4393 