### PR TITLE
Restore body after read so downstream consumers can access it again

### DIFF
--- a/static-mock/handle_static_mock_request.go
+++ b/static-mock/handle_static_mock_request.go
@@ -23,6 +23,9 @@ func (sms *StaticMockService) getBodyFromHttpRequest(request *http.Request) inte
 		panic(err)
 	}
 
+	// Restore request.Body so it can be read again
+	request.Body = io.NopCloser(bytes.NewReader(bodyBytes))
+
 	var bodyJsonObj interface{}
 
 	if len(bodyBytes) == 0 {


### PR DESCRIPTION
`getBodyFromHttpRequest` method in `static-mock/handle_static_mock_request.go` file was reading the body and then downstream consumers of request were unable to access the body object.

Updated logic to restore body so that downstream consumers can read it. 